### PR TITLE
feat: CLI for batch check and summary display

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="hasegawa@isp.co.jp">hsgwa</maintainer>
   <license>Apache License 2.0</license>
 
+  <exec_depend>tabulate</exec_depend>
   <depend>ros2cli</depend>
   <depend>caret_analyze</depend>
   <depend>caret_analyze_cpp_impl</depend>

--- a/ros2caret/verb/__init__.py
+++ b/ros2caret/verb/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from caret_analyze import Application, Lttng
 
-from logging import DEBUG, Formatter, getLogger, INFO, StreamHandler
+from logging import Formatter, getLogger, INFO, StreamHandler
 
 from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
 from ros2cli.plugin_system import satisfies_version
@@ -49,7 +49,6 @@ class VerbExtension:
         handler.setFormatter(formatter)
 
         logger = getLogger()
-        logger.setLevel(DEBUG)
         logger.addHandler(handler)
 
     def add_arguments(self, parser, cli_name):

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from caret_analyze import Application, Lttng
 
-from logging import getLogger
+from logging import getLogger, INFO
 import os
 import subprocess
 
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)
+logger.setLevel(INFO)
 
 
 galactic_tp_symbol_names = [

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from caret_analyze import Application, Lttng
+
+
+from caret_analyze import Lttng
+from ros2caret.verb import VerbExtension
+
+
+class CheckCTFVerb(VerbExtension):
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-d', '--trace_dir', dest='trace_dir', type=str,
+            help='the path to the trace directory to be checked', required=True)
+
+    def main(self, *, args):
+        lttng = Lttng(args.trace_dir)

--- a/ros2caret/verb/node_summary.py
+++ b/ros2caret/verb/node_summary.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from caret_analyze import Application, Lttng
+
+from logging import ERROR, getLogger
+
+from caret_analyze import Lttng
+from ros2caret.verb import VerbExtension
+from tabulate import tabulate
+
+
+class NodeSummaryVerb(VerbExtension):
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-d', '--trace_dir', dest='trace_dir', type=str,
+            help='the path to the trace directory', required=True)
+        parser.add_argument(
+            '-c', '--display_check', dest='display_check', action='store_true',
+            help='display the error checks to the trace results.', required=False)
+
+    def main(self, *, args):
+        if(not args.display_check):
+            logger = getLogger()
+            logger.setLevel(ERROR)
+
+        lttng = Lttng(args.trace_dir)
+        node_count_df = lttng.get_count(groupby=['node_name']).reset_index()
+        node_count_df.rename(columns={'size': 'number_of_trace_points'}, inplace=True)
+        node_count_df = node_count_df[node_count_df['node_name'] != '-']
+
+        print('\n')
+        print(tabulate(node_count_df,
+                       node_count_df.columns,
+                       tablefmt='presto',
+                       showindex=False))

--- a/ros2caret/verb/topic_summary.py
+++ b/ros2caret/verb/topic_summary.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from caret_analyze import Application, Lttng
+
+from logging import ERROR, getLogger
+
+from caret_analyze import Lttng
+from ros2caret.verb import VerbExtension
+from tabulate import tabulate
+
+
+class TopicSummaryVerb(VerbExtension):
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-d', '--trace_dir', dest='trace_dir', type=str,
+            help='the path to the trace directory', required=True)
+        parser.add_argument(
+            '-c', '--display_check', dest='display_check', action='store_true',
+            help='display the error checks to the trace results.', required=False)
+
+    def main(self, *, args):
+        if(not args.display_check):
+            logger = getLogger()
+            logger.setLevel(ERROR)
+
+        lttng = Lttng(args.trace_dir)
+        topic_count_df = lttng.get_count(groupby=['topic_name']).reset_index()
+        topic_count_df.rename(columns={'size': 'number_of_trace_points'}, inplace=True)
+        topic_count_df = topic_count_df[topic_count_df['topic_name'] != '-']
+
+        print('\n')
+        print(tabulate(topic_count_df,
+                       topic_count_df.columns,
+                       tablefmt='presto',
+                       showindex=False))

--- a/ros2caret/verb/trace_point_summary.py
+++ b/ros2caret/verb/trace_point_summary.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from caret_analyze import Application, Lttng
+
+from logging import ERROR, getLogger
+
+from caret_analyze import Lttng
+from ros2caret.verb import VerbExtension
+from tabulate import tabulate
+
+
+class TracePointSummaryVerb(VerbExtension):
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-d', '--trace_dir', dest='trace_dir', type=str,
+            help='the path to the trace directory', required=True)
+        parser.add_argument(
+            '-c', '--display_check', dest='display_check', action='store_true',
+            help='display the error checks to the trace results.', required=False)
+
+    def main(self, *, args):
+        if(not args.display_check):
+            logger = getLogger()
+            logger.setLevel(ERROR)
+
+        lttng = Lttng(args.trace_dir)
+        tp_count_df = lttng.get_count().reset_index()
+        tp_count_df.rename(columns={'size': 'number_of_trace_points'}, inplace=True)
+        print('\n')
+        print(tabulate(tp_count_df,
+                       tp_count_df.columns,
+                       tablefmt='presto',
+                       showindex=False))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,11 @@ setup(
             'ros2caret.verb = ros2caret.verb:VerbExtension'
         ],
         'ros2caret.verb': [
-            'check_caret_rclcpp = ros2caret.verb.check_caret_rclcpp:CheckCaretRclcppVerb'
+            'check_caret_rclcpp = ros2caret.verb.check_caret_rclcpp:CheckCaretRclcppVerb',
+            'check_ctf = ros2caret.verb.check_ctf:CheckCTFVerb',
+            'trace_point_summary = ros2caret.verb.trace_point_summary:TracePointSummaryVerb',
+            'topic_summary = ros2caret.verb.topic_summary:TopicSummaryVerb',
+            'node_summary = ros2caret.verb.node_summary:NodeSummaryVerb',
             # 'architecture = ros2caret.verb.architecture:ArchitectureVerb',
             # 'callback_graph = ros2caret.verb.callback_graph:CallbackGraphVerb',
             # 'chain_latency = ros2caret.verb.chain_latency:ChainLatencyVerb',


### PR DESCRIPTION
@hsgwa 
お疲れ様です。
[測定後の一括チェックツール作成](https://tier4.atlassian.net/browse/T4PB-17109)が完了したので、ご確認をお願いいたします。

lttng クラスを初期化する際に、Event_Counter クラスの [_validate](https://github.com/tier4/CARET_analyze/blob/f79dfe49c6cbeb81efd8223c6bb41f20b99f74a4/caret_analyze/infra/lttng/event_counter.py#L44) が実行され、LD_PRELOAD によるトレースポイントが入っているかのチェックも実施されるので、特にこのチェックに関して追加実装は不要でした。

サマリ表示では、-c オプションでチェックも兼ねることができるようになっています。（[こちらのスレッドの内容](https://emb4hq.slack.com/archives/C017YM4AA06/p1650940805273969?thread_ts=1650616341.892579&cid=C017YM4AA06)）
また、`lttng.get_count(groupby=['node_name'(または 'topic_name')]) `で取得できる dataframe の "topic_name" や "node_name" が "-" となっている行に関しては、値が取得できなかったものの総和になってしまうと考えたため、表示していません。

以下はコマンド実行時の出力結果です。
https://drive.google.com/drive/folders/1FX67Gl7DF9Jgw7sZorCBKNHyiyDJ5BwV?usp=sharing