### PR TITLE
fix: rename tabulate dependency to rosdep compliant. closes #11

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="hasegawa@isp.co.jp">hsgwa</maintainer>
   <license>Apache License 2.0</license>
 
-  <exec_depend>tabulate</exec_depend>
+  <exec_depend>python-tabulate-pip</exec_depend>
   <depend>ros2cli</depend>
   <depend>caret_analyze</depend>
   <test_depend>ament_copyright</test_depend>

--- a/ros2caret/verb/record_sim_time.py
+++ b/ros2caret/verb/record_sim_time.py
@@ -21,9 +21,10 @@ class RecordSimTime(VerbExtension):
         pass
 
     def main(self, *, args):
-        lttng = Lttng(args.trace_dir, force_conversion=True)
-        app = Application(args.architecture_path, 'yaml', lttng)
-        path = app.path[args.path_name]
+        raise NotImplementedError('disabled')
+        # lttng = Lttng(args.trace_dir, force_conversion=True)
+        # app = Application(args.architecture_path, 'yaml', lttng)
+        # path = app.path[args.path_name]
 
-        message_flow(path, export_path=args.output_path,
-                     granularity=args.granularity)
+        # message_flow(path, export_path=args.output_path,
+        #              granularity=args.granularity)

--- a/ros2caret/verb/record_sim_time.py
+++ b/ros2caret/verb/record_sim_time.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from caret_analyze import Application, Lttng
 
-
-from caret_analyze import Lttng
 from ros2caret.verb import VerbExtension
 
 
-class CheckCTFVerb(VerbExtension):
+class RecordSimTime(VerbExtension):
 
     def add_arguments(self, parser, cli_name):
-        parser.add_argument(
-            '-d', '--trace_dir', dest='trace_dir', type=str,
-            help='the path to the trace directory to be checked', required=True)
+        pass
 
     def main(self, *, args):
-        Lttng(args.trace_dir)
+        lttng = Lttng(args.trace_dir, force_conversion=True)
+        app = Application(args.architecture_path, 'yaml', lttng)
+        path = app.path[args.path_name]
+
+        message_flow(path, export_path=args.output_path,
+                     granularity=args.granularity)

--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from caret_analyze import Application, Lttng
+
 from ament_mypy.main import main
 
 import pytest


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>