### PR TITLE
fix: add nbconvert and nbformat with version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ pybind11
 pandas>=1.4.0
 bokeh
 pandas-bokeh
+nbformat>=5.4.0
+nbconvert>=6.4.4
 jupyterlab
 graphviz
 


### PR DESCRIPTION
jupyter-server と nbconvert のバージョン差異に起因して、古い ipynb ファイルを jupyter-notebook から開けないことがあったので、nbconvert （と、依存のある nbconvert）の必要バージョンを追記しました。