### PR TITLE
fix: check-caret-rclcpp logging output

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      
+
       - name: Install LTTng
         run: |
           sudo apt-get update
@@ -26,6 +26,7 @@ jobs:
           sudo apt install -y ros-galactic-ament-flake8
           sudo apt install -y ros-galactic-ament-pep257
           sudo apt install -y ros-galactic-ament-mypy
+          sudo apt install -y python3-pytest-mock
         shell: bash
 
       # - name: Clone dependency packages

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-mock</test_depend>
   <test_depend>ament_mypy</test_depend>
 
   <export>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:launch -p no:launch_ros

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -p no:launch -p no:launch_ros
+

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -12,14 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from caret_analyze import Application, Lttng
 
-from logging import getLogger, INFO
+from __future__ import annotations
+
+from logging import Formatter, getLogger, INFO, StreamHandler
+
 import os
+
 import subprocess
+from typing import Callable, List, Set
 
 from ros2caret.verb import VerbExtension
 
+handler = StreamHandler()
+handler.setLevel(INFO)
+
+fmt = '%(levelname)-8s: %(asctime)s | %(message)s'
+formatter = Formatter(
+    fmt,
+    datefmt='%Y-%m-%d %H:%M:%S')
+handler.setFormatter(formatter)
+
 logger = getLogger(__name__)
 logger.setLevel(INFO)
+logger.addHandler(handler)
+
 
 class CheckCaretRclcppVerb(VerbExtension):
 

--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from caret_analyze import Application, Lttng
 
+import os
+
 from ament_mypy.main import main
 
 import pytest
 
 
+reason = '[mypy test is to be officially supported in v0.4 or later.]'
+
+
+@pytest.mark.skipif('GITHUB_ACTION' in os.environ, reason=reason)
 @pytest.mark.mypy
 @pytest.mark.linter
 def test_mypy():

--- a/test/verb/test_check_caret_rclcpp.py
+++ b/test/verb/test_check_caret_rclcpp.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from caret_analyze import Application, Lttng
+
 from logging import ERROR, INFO, WARNING
 
 from ros2caret.verb.check_caret_rclcpp import RclcppCheck

--- a/test/verb/test_check_caret_rclcpp.py
+++ b/test/verb/test_check_caret_rclcpp.py
@@ -62,10 +62,10 @@ class TestCheckCaretRclcpp:
 
     def test_get_package_name(self):
         get_package_name = RclcppCheck._create_get_package_name('')
-        assert get_package_name('foo/bar/hoge') == 'foo'
+        assert get_package_name('foo/bar/baz') == 'foo'
 
         get_package_name = RclcppCheck._create_get_package_name('foo/')
-        assert get_package_name('foo/bar/hoge') == 'bar'
+        assert get_package_name('foo/bar/baz') == 'bar'
 
         get_package_name = RclcppCheck._create_get_package_name('foo/bar/')
-        assert get_package_name('foo/bar/hoge') == 'hoge'
+        assert get_package_name('foo/bar/baz') == 'baz'

--- a/test/verb/test_check_caret_rclcpp.py
+++ b/test/verb/test_check_caret_rclcpp.py
@@ -1,0 +1,57 @@
+from logging import ERROR, INFO, WARNING
+
+from ros2caret.verb.check_caret_rclcpp import RclcppCheck
+
+
+class TestCheckCaretRclcpp:
+
+    def test_file_exist(self, caplog, mocker):
+        mocker.patch('os.path.exists', return_value=True)
+        mocker.patch(
+            'ros2caret.verb.check_caret_rclcpp.RclcppCheck._get_obj_paths', return_value=[])
+        RclcppCheck('')
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == INFO
+
+    def test_ng_case(self, caplog, mocker):
+        mocker.patch('os.path.exists', return_value=True)
+        base_path = 'ros2caret.verb.check_caret_rclcpp.RclcppCheck.'
+        mocker.patch(base_path+'_get_obj_paths', return_value=[''])
+        mocker.patch(base_path+'_has_caret_rclcpp_tp', return_value=False)
+
+        RclcppCheck('')
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == WARNING
+
+    def test_ok_case(self, caplog, mocker):
+        mocker.patch('os.path.exists', return_value=True)
+        base_path = 'ros2caret.verb.check_caret_rclcpp.RclcppCheck.'
+        mocker.patch(base_path+'_get_obj_paths', return_value=[''])
+        mocker.patch(base_path+'_has_caret_rclcpp_tp', return_value=True)
+
+        RclcppCheck('')
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == INFO
+
+    def test_file_not_exist(self, caplog, mocker):
+        mocker.patch('os.path.exists', return_value=False)
+        try:
+            RclcppCheck('')
+        except SystemExit as e:
+            assert e.args == (1,)
+            assert len(caplog.records) == 1
+            record = caplog.records[0]
+            assert record.levelno == ERROR
+
+    def test_get_package_name(self):
+        get_package_name = RclcppCheck._create_get_package_name('')
+        assert get_package_name('foo/bar/hoge') == 'foo'
+
+        get_package_name = RclcppCheck._create_get_package_name('foo/')
+        assert get_package_name('foo/bar/hoge') == 'bar'
+
+        get_package_name = RclcppCheck._create_get_package_name('foo/bar/')
+        assert get_package_name('foo/bar/hoge') == 'hoge'


### PR DESCRIPTION
I have removed the logging handler during PR #17  (https://github.com/tier4/ros2caret/pull/17/commits/666bc220cd4991779a75565824e27429dcc6df82 ) so that check caret_rclcpp log message were removed for my mistake.
This PR is a patch to make the log output during caret_rclcpp_check.
