### PR TITLE
chore: modify test_copyright path

### DIFF
--- a/test/test_copyright.py
+++ b/test/test_copyright.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=['.', 'test'])
+    rc = main(argv=['./ros2caret', 'test'])
     assert rc == 0, 'Found errors'


### PR DESCRIPTION
If copyright.md is included in the test target, test_copyright will fail.
This patch limits the test target to src and test only.

Signed-off-by: hsgwa <hasegawa.isp@gmail.com>