### PR TITLE
fix: lttng has no attribute last filters

### DIFF
--- a/ros2caret/verb/summary.py
+++ b/ros2caret/verb/summary.py
@@ -41,6 +41,7 @@ class Summary:
                                     args.s_filter_args)
         self._lttng = Lttng(args.trace_dir, event_filters=filters)
         self._summary_df = self._get_summary_df(self._lttng, groupby)
+        self._filtered = len(filters) > 0
 
     def print_summary(
         self
@@ -58,7 +59,7 @@ class Summary:
         except AttributeError as e:
             logger.error(f'{e}. Please update caret_analyze.')
 
-        if Lttng._last_filters:
+        if self._filtered:
             fi_bt, fi_et = Summary._get_filtered_range(self._lttng)
             msg += (
                 'Filtered trace range    | '


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>


This PR fixes following error:

```
autoware@38a3ea7915c2:~/ros2_ws/evaluate$ ros2 caret node_summary -d end_to_end_sample/
Traceback (most recent call last):
  File "/opt/ros/galactic/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli==0.13.1', 'console_scripts', 'ros2')()
  File "/opt/ros/galactic/lib/python3.8/site-packages/ros2cli/cli.py", line 67, in main
    rc = extension.main(parser=parser, args=args)
  File "/home/autoware/ros2_caret/build/ros2caret/ros2caret/command/caret.py", line 32, in main
    return extension.main(args=args)
  File "/home/autoware/ros2_caret/build/ros2caret/ros2caret/verb/node_summary.py", line 49, in main
    summary.print_summary()
  File "/home/autoware/ros2_caret/build/ros2caret/ros2caret/verb/summary.py", line 61, in print_summary
    if Lttng._last_filters:
AttributeError: type object 'Lttng' has no attribute '_last_filters'
```

This error was caused by https://github.com/tier4/CARET_analyze/pull/118/files#diff-0e36d4ac4972c4fd06b414569919cf9e530d05ce15a7bbb131befa5fa6a118cfL227