### PR TITLE
test: pass test in PYTHONPATH set environment

### DIFF
--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -22,12 +22,10 @@ try:
     Architecture = caret_analyze.Architecture
     Error = caret_analyze.exceptions.Error
     CatchErrors = (OSError, Error)
-    CaretAnalyzeEnabled = True
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
         Architecture = None
         CatchErrors = OSError
-        CaretAnalyzeEnabled = False
     else:
         raise(e)
 
@@ -81,10 +79,10 @@ class CreateArchitecture:
         trace_dir: str,
         architecture: Optional[Architecture] = None
     ) -> None:
-        if CaretAnalyzeEnabled:
-            self._arch = Architecture('lttng', trace_dir)
-        else:
+        if architecture:
             self._arch = architecture
+        else:
+            self._arch = Architecture('lttng', trace_dir)
 
     def create(self, output_path: str, force: bool) -> None:
         try:

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -19,11 +19,9 @@ from typing import List, Optional
 try:
     import caret_analyze
     Architecture = caret_analyze.Architecture
-    CaretAnalyzeEnabled = True
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
         Architecture = None
-        CaretAnalyzeEnabled = False
     else:
         raise(e)
 
@@ -70,10 +68,10 @@ class VerifyPaths:
         arch_path: str,
         architecture: Optional[Architecture] = None
     ) -> None:
-        if CaretAnalyzeEnabled:
-            self._arch = Architecture('yaml', arch_path)
-        else:
+        if architecture:
             self._arch = architecture
+        else:
+            self._arch = Architecture('yaml', arch_path)
 
     def verify(
         self,


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

The current implementation passes the test in an environment where PYTHONPATH is not set.

However, when PYTHONPATH is set correctly, some tests failue.

1. CaretAnalyzeEnabled is set to true.
2. Architecture('') throws an exception.

This PR fixes to pass all tests.