### PR TITLE
feat: add caret record CLI

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -37,7 +37,7 @@ class RecordVerb(VerbExtension):
             '(default: %(default)s)')
         parser.add_argument(
             '-v', '--verbose', dest='verbose', action='store_true',
-            help='dieplay status of recording')
+            help='display status of recording')
 
     def main(self, *, args):
         events_ust = ['ros*']

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -44,17 +44,19 @@ class RecordVerb(VerbExtension):
         context_fields = names.DEFAULT_CONTEXT
         events_kernel = []
 
+        # Note: since key name of context_fields differs in galactic and humble,
+        # here, arguments are given as tuple.
         init(
-            session_name=args.session_name,
-            base_path=args.path,
-            ros_events=events_ust,
-            kernel_events=events_kernel,
-            context_fields=context_fields,
-            display_list=args.list,
+            args.session_name,
+            args.path,
+            events_ust,
+            events_kernel,
+            context_fields,
+            args.list,
         )
 
         fini(
-            session_name=args.session_name,
+            args.session_name,
         )
 
         return 0

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -1,0 +1,60 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2caret.verb import VerbExtension
+
+from tracetools_trace.tools import names, path
+from tracetools_trace.trace import fini
+from tracetools_trace.trace import init
+
+
+class RecordVerb(VerbExtension):
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-s', '--session-name', dest='session_name',
+            default=path.append_timestamp('session'),
+            help='the name of the tracing session (default: session-YYYYMMDDHHMMSS)')
+        parser.add_argument(
+            '-p', '--path', dest='path',
+            help='path of the base directory for trace data (default: '
+            '$ROS_TRACE_DIR if ROS_TRACE_DIR is set and not empty, or $ROS_HOME/tracing,'
+            ' using ~/.ros for ROS_HOME if not set or if empty)')
+        parser.add_argument(
+            '-l', '--list', dest='list', action='store_true',
+            help='display lists of enabled events and context names '
+            '(default: %(default)s)')
+        parser.add_argument(
+            '-v', '--verbose', dest='verbose', action='store_true',
+            help='dieplay status of recording')
+
+    def main(self, *, args):
+        events_ust = ['ros*']
+        context_fields = names.DEFAULT_CONTEXT
+        events_kernel = []
+
+        init(
+            session_name=args.session_name,
+            base_path=args.path,
+            ros_events=events_ust,
+            kernel_events=events_kernel,
+            context_fields=context_fields,
+            display_list=args.list,
+        )
+
+        fini(
+            session_name=args.session_name,
+        )
+
+        return 0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
                     ros2caret.verb.create_architecture:CreateArchitectureVerb',
             'verify_paths = \
                     ros2caret.verb.verify_paths:VerifyPathsVerb',
+            'record = \
+                    ros2caret.verb.record:RecordVerb',
             # 'callback_graph = \
             #       ros2caret.verb.callback_graph:CallbackGraphVerb',
             # 'chain_latency = ros2caret.verb.chain_latency:ChainLatencyVerb',


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR add new CLI:
```bash
ros2 caret record
```
This is just a wrapper of following:
```bash
ros2 trace -k -u "ros*"
```

I'm planning to add some features to `ros2 caret record`

- automatic run clock recorder node
   - `ros2 run caret_trace clock_recorder`.
- automatic run node to publish record_start/record_end topic
   -  https://github.com/tier4/ros2caret/pull/34
- add caret_light option.