### PR TITLE
fix: fix non-binary files to be unchecked in check_caret_rclcpp

### DIFF
--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -135,20 +135,24 @@ class RclcppCheck():
     def _has_galactic_tp(obj_path: str) -> bool:
         cmd = (f'nm -D {obj_path} | '
                f'grep -e {" -e ".join(galactic_tp_symbol_names)}')
-        return (subprocess.Popen(cmd,
-                                 stdout=subprocess.PIPE,
-                                 shell=True).communicate()[0]
-                )
+        stdout = (subprocess.Popen(cmd,
+                                   stdout=subprocess.PIPE,
+                                   shell=True).communicate()[0]
+                  )
+
+        return True if stdout else False
 
     @staticmethod
     def _has_caret_rclcpp_tp(obj_path: str) -> bool:
         cmd = (f'nm -D {obj_path} | '
                f'grep -e {" -e ".join(caret_fork_tp_symbol_names)}')
-        return (subprocess.Popen(cmd,
-                                 stdout=subprocess.PIPE,
-                                 shell=True
-                                 ).communicate()[0]
-                ).decode('utf-8')
+        stdout = (subprocess.Popen(cmd,
+                                   stdout=subprocess.PIPE,
+                                   shell=True
+                                   ).communicate()[0]
+                  ).decode('utf-8')
+
+        return True if stdout else False
 
     @staticmethod
     def _create_get_package_name(root_dir_path: str) -> Callable[[str], bool]:

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -120,7 +120,12 @@ class RclcppCheck():
                 ! -name "*.includecache" ! -name "*.in" \
                 ! -name "*.txt"          ! -name "*.a" \
                 ! -name "*.stamp"        ! -name "*.genexp" \
-                ! -name "*.sample"       ! -name "*.py"'
+                ! -name "*.sample"       ! -name "*.py" \
+                ! -name "*.cu"           ! -name "*.sh" \
+                ! -name "*.md"           ! -name "polygraphy" \
+                ! -name "*.jpg"          ! -name "*.ipynb" \
+                ! -name "*.png"'
+
         return (subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  shell=True).communicate()[0]

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -139,7 +139,7 @@ class RclcppCheck():
                                    shell=True).communicate()[0]
                   )
 
-        return True if stdout else False
+        return bool(stdout)
 
     @staticmethod
     def _has_caret_rclcpp_tp(obj_path: str) -> bool:
@@ -151,7 +151,7 @@ class RclcppCheck():
                                    ).communicate()[0]
                   ).decode('utf-8')
 
-        return True if stdout else False
+        return bool(stdout)
 
     @staticmethod
     def _create_get_package_name(root_dir_path: str) -> Callable[[str], bool]:

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -123,9 +123,8 @@ class RclcppCheck():
                 ! -name "*.sample"       ! -name "*.py" \
                 ! -name "*.cu"           ! -name "*.sh" \
                 ! -name "*.md"           ! -name "polygraphy" \
-                ! -name "*.jpg"          ! -name "*.ipynb" \
-                ! -name "*.png"'
-
+                ! -name "gen-data"       ! -name "*.ipynb" \
+                ! -name "*.png"          ! -name "*.jpg"'
         return (subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  shell=True).communicate()[0]


### PR DESCRIPTION
This PR modifies non-binary files to be unchecked in `ros2 caret check_caret_rclcpp` command.
This bug was reported in the following ticket: 
https://tier4.atlassian.net/browse/T4PB-22214