### PR TITLE
chore(pytest): add no:launch_testing for caplog test in humble

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,7 @@ addopts = -p no:launch -p no:launch_ros -p no:launch_testing
 #
 # 3. execute "up" to call importlib-related function
 #
-# 4. check arguments for impotlib.import_module()
+# 4. check arguments for importlib.import_module()
 #    'launch_testing.XXX.YYY' can be found.
 #
 # 5. add -p no:launch_testing to adopts argument

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,18 @@
 [pytest]
 addopts = -p no:launch -p no:launch_ros -p no:launch_testing
+# How to add adopts arguments
+#
+# 1. add breakpoint to self.propaget = False
+#    ref. /opt/ros/humble/lib/python3.10/site-packages/launch/logging/__init__.py
+#         https://github.com/ros2/launch/blob/humble/launch/launch/logging/__init__.py#L482
+#
+# 2. run pytest, then stop at break point.
+#
+# 3. execute "up" to call importlib-related function
+#
+# 4. check arguments for impotlib.impor_module()
+#    'launch_testing.XXX.YYY' can be found.
+#
+# 5. add -p no:launch_testing to adopts argument
+#
 # ref. https://stackoverflow.com/a/65261267

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-addopts = -p no:launch -p no:launch_ros
+addopts = -p no:launch -p no:launch_ros -p no:launch_testing
+# ref. https://stackoverflow.com/a/65261267

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 addopts = -p no:launch -p no:launch_ros -p no:launch_testing
 # How to add adopts arguments
 #
-# 1. add breakpoint to self.propaget = False
+# 1. add breakpoint to self.propagate = False
 #    ref. /opt/ros/humble/lib/python3.10/site-packages/launch/logging/__init__.py
 #         https://github.com/ros2/launch/blob/humble/launch/launch/logging/__init__.py#L482
 #
@@ -10,7 +10,7 @@ addopts = -p no:launch -p no:launch_ros -p no:launch_testing
 #
 # 3. execute "up" to call importlib-related function
 #
-# 4. check arguments for impotlib.impor_module()
+# 4. check arguments for impotlib.import_module()
 #    'launch_testing.XXX.YYY' can be found.
 #
 # 5. add -p no:launch_testing to adopts argument


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

In humble, testing of logs using caplog fails.
This PR is a fix to make caplog test pass in humble as well as galactic.