### PR TITLE
chore: make force option work without argument

### DIFF
--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -62,7 +62,7 @@ class CreateArchitectureVerb(VerbExtension):
             required=False, default='./architecture.yaml'
         )
         parser.add_argument(
-            '-f', '--force', dest='force', type=bool,
+            '-f', '--force', dest='force', action='store_true',
             help='allow overwrite of architecture file',
             required=False, default=False
         )


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR make `--force` option work without argument.
