### PR TITLE
chore: add some ignore file extensions into check_caret_rclcpp

### DIFF
--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -124,7 +124,8 @@ class RclcppCheck():
                 ! -name "*.cu"           ! -name "*.sh" \
                 ! -name "*.md"           ! -name "polygraphy" \
                 ! -name "gen-data"       ! -name "*.ipynb" \
-                ! -name "*.png"          ! -name "*.jpg"'
+                ! -name "*.png"          ! -name "*.jpg" \
+                ! -name "*.json"         ! -name "*.toml"'
         return (subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  shell=True).communicate()[0]


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR add some ignore file extensions into `ros2 caret check_caret_rclcpp`.
Image when the bug occurs:
![Screenshot from 2022-11-21 13-17-18](https://user-images.githubusercontent.com/55824710/203493847-6c3f1b7f-fbbf-4cc4-8abd-548a82b368be.png)
