### PR TITLE
feat: add light mode

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -130,9 +130,27 @@ class RecordVerb(VerbExtension):
             help=('recording frequency for Initialization-related trace points (default: 100Hz). '
                   'Higher frequencies allow recording in a shorter time. '
                   'However, the possibility of recording failure increases. '))
+        parser.add_argument(
+            '--light', dest='light_mode', action='store_true',
+            help='light mode (record high level events only)')
 
     def main(self, *, args):
-        events_ust = ['ros*']
+        if args.light_mode:
+            events_ust = [
+                    'ros2:*callback*',
+                    'ros2_caret:*callback*',
+                    'ros2:dispatch*',
+                    'ros2_caret:dispatch*',
+                    'ros2:rclcpp*',
+                    'ros2_caret:rclcpp*',
+                    'ros2_caret:rmw*',
+                    '*callback_group*',
+                    'ros2_caret:*executor',
+                    'ros2_caret:dds_bind*',
+                    'ros2:rcl_*init',
+                    'ros2_caret:rcl_*init']
+        else:
+            events_ust = ['ros*']
         context_names = names.DEFAULT_CONTEXT
         events_kernel = []
 

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -148,7 +148,8 @@ class RecordVerb(VerbExtension):
                     'ros2_caret:*executor',
                     'ros2_caret:dds_bind*',
                     'ros2:rcl_*init',
-                    'ros2_caret:rcl_*init']
+                    'ros2_caret:rcl_*init',
+                    'ros2_caret:caret_init']
         else:
             events_ust = ['ros*']
         context_names = names.DEFAULT_CONTEXT


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

Add light mode ( `ros2 caret record --light` ) to record high level events only.

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-24855)

## Notes for reviewers

There seems a problem to visualize message flow

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
