### PR TITLE
chore: support for non-optional arguments `append-trace` added from I-turtle.

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -164,6 +164,9 @@ class RecordVerb(VerbExtension):
         init_args['base_path'] = args.path
         init_args['ros_events'] = events_ust
         init_args['kernel_events'] = events_kernel
+        # Note: keyword argument --append-trace has been added since iron.
+        if os.environ['ROS_DISTRO'] == 'iron' or os.environ['ROS_DISTRO'] == 'rolling':
+            init_args['append_trace'] = True
         # Note: key name of context_fields differs in galactic and humble,
         if os.environ['ROS_DISTRO'] == 'galactic':
             init_args['context_names'] = context_names


### PR DESCRIPTION
## Description
 Since iron-irwini, ros2_tracing has added a non-optional argument `--append-trace` for lttng session start. When `append-trace`=False, if the directory with the specified session name already exists, an error is output and the process is terminated. Default arguments were set to ensure the same behaviour as before in measurements using CARET.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- https://github.com/ros2/ros2_tracing/pull/58

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
