### PR TITLE
fix: import module for annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from setuptools import setup


### PR DESCRIPTION
## Description

### Why this PR is needed

`list` annotation is added in [this PR](https://github.com/tier4/ros2caret/pull/69/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R7), but description to import module is missed. It works with Python 3.10 where `from __future__ import annotations` is added by default, but it don't work with <Python 3.10.

### What is changed

`from __future__ import annotations` is added


## Related links

https://tier4.atlassian.net/browse/RT2-896

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
