### PR TITLE
feat: support non-optional argument `append-trace`

### DIFF
--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -12,6 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This code extends the functionality of
+# https://github.com/ros2/ros2_tracing/blob/rolling/tracetools_trace/tracetools_trace/trace.py.
+# As a result, many parts have been reused from the above file.
+# Changes are following:
+#   - Support for different interfaces across different ROS2 Distributions.
+# The copyright of original code is as follows:
+
+# Copyright 2019 Robert Bosch GmbH
+# Copyright 2021 Christophe Bedard
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 from typing import List

--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -1,0 +1,104 @@
+# Copyright 2023 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+from typing import List
+from typing import Optional
+
+from tracetools_trace.tools import lttng
+from tracetools_trace.tools import path
+from tracetools_trace.tools import print_names_list
+
+def init(
+    *,
+    session_name: str,
+    base_path: Optional[str],
+    ros_events: List[str],
+    kernel_events: List[str],
+    context_fields: List[str],
+    display_list: bool = False,
+    append_trace: bool = True,
+) -> bool:
+    """
+    Init and start tracing.
+
+    Raises RuntimeError on failure, in which case the tracing session might still exist.
+
+    :param session_name: the name of the session
+    :param base_path: the path to the directory in which to create the tracing session directory,
+        or `None` for default
+    :param append_trace: whether to append to the trace directory if it already exists, otherwise
+        an error is reported
+    :param ros_events: list of ROS events to enable
+    :param kernel_events: list of kernel events to enable
+    :param context_fields: list of context fields to enable
+    :param display_list: whether to display list(s) of enabled events and context names
+    :return: True if successful, False otherwise
+    """
+    # Check if LTTng is installed right away before printing anything
+    if not lttng.is_lttng_installed():
+        sys.exit(2)
+
+    ust_enabled = len(ros_events) > 0
+    kernel_enabled = len(kernel_events) > 0
+    if ust_enabled:
+        print(f'UST tracing enabled ({len(ros_events)} events)')
+        if display_list:
+            print_names_list(ros_events)
+    else:
+        print('UST tracing disabled')
+    if kernel_enabled:
+        print(f'kernel tracing enabled ({len(kernel_events)} events)')
+        if display_list:
+            print_names_list(kernel_events)
+    else:
+        print('kernel tracing disabled')
+    if len(context_fields) > 0:
+        print(f'context ({len(context_fields)} fields)')
+        if display_list:
+            print_names_list(context_fields)
+
+    if not base_path:
+        base_path = path.get_tracing_directory()
+    full_session_path = os.path.join(base_path, session_name)
+
+    print(f'writing tracing session to: {full_session_path}')
+
+    input('press enter to start...')
+    # for iron, rolling
+    if os.environ['ROS_DISTRO'] in ['iron', 'rolling']:
+        trace_directory = lttng.lttng_init(
+            session_name=session_name,
+            base_path=base_path,
+            append_trace=append_trace,
+            ros_events=ros_events,
+            kernel_events=kernel_events,
+            context_fields=context_fields,
+        )
+    # for humble
+    else:
+        trace_directory = lttng.lttng_init(
+            session_name=session_name,
+            base_path=base_path,
+            ros_events=ros_events,
+            kernel_events=kernel_events,
+            context_fields=context_fields,
+        )
+
+    if trace_directory is None:
+        return False
+    # Simple sanity check
+    assert trace_directory == full_session_path
+    return True

--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# このファイルの多くの部分は以下のファイルから流用しています。
+# Many parts of this file have been reused from the following file.
 #   https://github.com/ros2/ros2_tracing/blob/0d9883c183244d4ac8f35e0e759b0642f5f91014/
 #   tracetools_trace/tracetools_trace/trace.py
 # The copyright of original code is as follows:

--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This code extends the functionality of
-# https://github.com/ros2/ros2_tracing/blob/rolling/tracetools_trace/tracetools_trace/trace.py.
-# As a result, many parts have been reused from the above file.
-# Changes are following:
-#   - Support for different interfaces across different ROS2 Distributions.
+# このファイルの多くの部分は以下のファイルから流用しています。
+#   https://github.com/ros2/ros2_tracing/blob/0d9883c183244d4ac8f35e0e759b0642f5f91014/
+#   tracetools_trace/tracetools_trace/trace.py
 # The copyright of original code is as follows:
 
 # Copyright 2019 Robert Bosch GmbH

--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Many parts of this file have been reused from the following file.
-#   https://github.com/ros2/ros2_tracing/blob/0d9883c183244d4ac8f35e0e759b0642f5f91014/
+#   https://github.com/ros2/ros2_tracing/blob/236e4b90a5ff6cdffa5a881717c473563370c0fc/
 #   tracetools_trace/tracetools_trace/trace.py
 # The copyright of original code is as follows:
 

--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -21,6 +21,7 @@ from tracetools_trace.tools import lttng
 from tracetools_trace.tools import path
 from tracetools_trace.tools import print_names_list
 
+
 def init(
     *,
     session_name: str,

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -170,7 +170,6 @@ class RecordVerb(VerbExtension):
         else:
             init_args['context_fields'] = context_names
         init_args['display_list'] = args.list
-
         init(**init_args)
 
         def _run():

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -21,10 +21,10 @@ from caret_msgs.msg import End, Start, Status
 import rclpy
 from rclpy import qos
 from rclpy.node import Node
+from tqdm import tqdm
 
 from ros2caret.verb import VerbExtension
-from .caret_record_init import init
-from tqdm import tqdm
+from ros2caret.verb.caret_record_init import init
 
 from tracetools_trace.tools import lttng, names, path
 from tracetools_trace.tools.signals import execute_and_handle_sigint

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -23,11 +23,11 @@ from rclpy import qos
 from rclpy.node import Node
 
 from ros2caret.verb import VerbExtension
+from .caret_record_init import init
 from tqdm import tqdm
 
 from tracetools_trace.tools import lttng, names, path
 from tracetools_trace.tools.signals import execute_and_handle_sigint
-from tracetools_trace.trace import init
 
 
 class CaretSessionNode(Node):
@@ -170,6 +170,7 @@ class RecordVerb(VerbExtension):
         else:
             init_args['context_fields'] = context_names
         init_args['display_list'] = args.list
+
         init(**init_args)
 
         def _run():

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -21,10 +21,11 @@ from caret_msgs.msg import End, Start, Status
 import rclpy
 from rclpy import qos
 from rclpy.node import Node
-from tqdm import tqdm
 
 from ros2caret.verb import VerbExtension
 from ros2caret.verb.caret_record_init import init
+
+from tqdm import tqdm
 
 from tracetools_trace.tools import lttng, names, path
 from tracetools_trace.tools.signals import execute_and_handle_sigint


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Since iron-irwini, ros2_tracing has added a non-optional argument `--append-trace` for lttng session start. When append-trace=False, if the directory with the specified session name already exists, an error is output and the process is terminated. Default arguments were set to ensure the same behaviour as before in measurements using CARET.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://github.com/tier4/ros2caret/pull/72

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
