### PR TITLE
feat: support light mode for iron

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -164,6 +164,8 @@ class RecordVerb(VerbExtension):
                     'ros2:rcl_*init',
                     'ros2_caret:rcl_*init',
                     'ros2_caret:caret_init']
+            if os.environ['ROS_DISTRO'] in ['iron' or'rolling']:
+                events_ust.append('ros2:rcl_publish')
         else:
             events_ust = ['ros*']
         context_names = names.DEFAULT_CONTEXT

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -164,7 +164,7 @@ class RecordVerb(VerbExtension):
                     'ros2:rcl_*init',
                     'ros2_caret:rcl_*init',
                     'ros2_caret:caret_init']
-            if os.environ['ROS_DISTRO'] in ['iron' or'rolling']:
+            if os.environ['ROS_DISTRO'] in ['iron' or 'rolling']:
                 events_ust.append('ros2:rcl_publish')
         else:
             events_ust = ['ros*']

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -21,7 +21,6 @@ from caret_msgs.msg import End, Start, Status
 import rclpy
 from rclpy import qos
 from rclpy.node import Node
-from tqdm import tqdm
 
 from ros2caret.verb import VerbExtension
 from ros2caret.verb.caret_record_init import init

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -21,6 +21,7 @@ from caret_msgs.msg import End, Start, Status
 import rclpy
 from rclpy import qos
 from rclpy.node import Node
+from tqdm import tqdm
 
 from ros2caret.verb import VerbExtension
 from ros2caret.verb.caret_record_init import init


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In CARET(humble), the publisher_handle was held by the ros2:rcl_publish and ros2:rclcpp_publish events.
However, in the ros2/ros2_tracing package, only the ros2:rcl_publish event retains information about the publisher_handle.
The ros2caret package provides a light mode for recording high-level events only.
Since the light mode assumes that ros2:rclcpp_publish holds the publisher_handle, it requires minor fix. 


### Changes
- In distributions after Iron, record `ros2:rcl_publish` during measurements in light mode.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://github.com/tier4/CARET_trace/pull/136
- https://github.com/tier4/CARET_analyze/pull/302

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
