### PR TITLE
feat: add option for record start immediately

### DIFF
--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -53,6 +53,7 @@ def init(
     subbuffer_size_kernel: int,
     display_list: bool = False,
     append_trace: bool = True,
+    immediate: bool = False,
 ) -> bool:
     """
     Init and start tracing.
@@ -101,7 +102,8 @@ def init(
 
     print(f'writing tracing session to: {full_session_path}')
 
-    input('press enter to start...')
+    if not immediate:
+        input('press enter to start...')
     # for iron, rolling
     if os.environ['ROS_DISTRO'] in ['iron', 'rolling']:
         trace_directory = lttng.lttng_init(

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -146,6 +146,9 @@ class RecordVerb(VerbExtension):
             help='the size of the subbuffers for kernel events(default: 32*4096). '
                  'buffer size must be power of two. '
                  'available in iron or rolling only. ')
+        parser.add_argument(
+            '--immediate', dest='immediate', action='store_true',
+            help='record immediately. ')
 
     def main(self, *, args):
         if args.light_mode:
@@ -202,6 +205,7 @@ class RecordVerb(VerbExtension):
         if args.subbuffer_size_kernel & (args.subbuffer_size_kernel-1):
             raise ValueError('--subbuffer-size-kernel value must be power of two.')
         init_args['subbuffer_size_kernel'] = args.subbuffer_size_kernel
+        init_args['immediate'] = args.immediate
         init(**init_args)
 
         def _run():


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR adds option for recording immediately.
If the immediately option is True, the recording starts without waiting for the user to press Enter when the measurement starts.

usage:
```
ros2 caret record --immediate
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://tier4.atlassian.net/browse/RT2-927

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
