### PR TITLE
feat: add record-clock option

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -230,7 +230,9 @@ class RecordVerb(VerbExtension):
 
         if args.record_clock:
             // cspell: ignore preexec, setpgrp
-            clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace', 'clock_recorder'], preexec_fn=os.setpgrp)
+            clock_recorder = subprocess.Popen(
+                ['ros2', 'run', 'caret_trace', 'clock_recorder'],
+                preexec_fn=os.setpgrp)
         else:
             clock_recorder = None
         execute_and_handle_sigint(_run, _fini)

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -223,13 +223,13 @@ class RecordVerb(VerbExtension):
             node.stop_progress()
             node.end()
             if clock_recorder:
-                // cspell: ignore killpg, getpgid
+                # cspell: ignore killpg, getpgid
                 os.killpg(os.getpgid(clock_recorder.pid), signal.SIGTERM)
             print('stopping & destroying tracing session')
             lttng.lttng_fini(session_name=args.session_name)
 
         if args.record_clock:
-            // cspell: ignore preexec, setpgrp
+            # cspell: ignore preexec, setpgrp
             clock_recorder = subprocess.Popen(
                 ['ros2', 'run', 'caret_trace', 'clock_recorder'],
                 preexec_fn=os.setpgrp)

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -14,6 +14,7 @@
 
 import os
 import subprocess
+import signal
 
 from typing import Optional
 
@@ -222,12 +223,12 @@ class RecordVerb(VerbExtension):
             node.stop_progress()
             node.end()
             if clock_recorder:
-                clock_recorder.terminate()
+                os.killpg(os.getpgid(clock_recorder.pid), signal.SIGTERM)
             print('stopping & destroying tracing session')
             lttng.lttng_fini(session_name=args.session_name)
 
         if args.record_clock:
-            clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace', 'clock_recorder'])
+            clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace', 'clock_recorder'], preexec_fn=os.setpgrp)
         else:
             clock_recorder = None
         execute_and_handle_sigint(_run, _fini)

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -223,11 +223,13 @@ class RecordVerb(VerbExtension):
             node.stop_progress()
             node.end()
             if clock_recorder:
+                // cspell: ignore killpg, getpgid
                 os.killpg(os.getpgid(clock_recorder.pid), signal.SIGTERM)
             print('stopping & destroying tracing session')
             lttng.lttng_fini(session_name=args.session_name)
 
         if args.record_clock:
+            // cspell: ignore preexec, setpgrp
             clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace', 'clock_recorder'], preexec_fn=os.setpgrp)
         else:
             clock_recorder = None

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import subprocess
 import signal
+import subprocess
 
 from typing import Optional
 

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -227,7 +227,7 @@ class RecordVerb(VerbExtension):
             lttng.lttng_fini(session_name=args.session_name)
 
         if args.record_clock:
-            clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace, 'clock_recorder'])
+            clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace', 'clock_recorder'])
         else:
             clock_recorder = None
         execute_and_handle_sigint(_run, _fini)

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -227,7 +227,7 @@ class RecordVerb(VerbExtension):
             lttng.lttng_fini(session_name=args.session_name)
 
         if args.record_clock:
-            clock_recorder = subprocess.Popen('ros2 run caret_trace clock_recorder', shell=True)
+            clock_recorder = subprocess.Popen(['ros2', 'run', 'caret_trace, 'clock_recorder'])
         else:
             clock_recorder = None
         execute_and_handle_sigint(_run, _fini)


### PR DESCRIPTION
## Description
This PR adds the `--record-clock` option for launching the node where the /clock topic is stored to use ROS time.

## Related links
- [Discussion](https://star4.slack.com/archives/C05311Y9L2X/p1696985902870339)
- [Performance evaluation](https://tier4.atlassian.net/wiki/spaces/~6422e65c57f0c028e2f72804/pages/2914091021/clock+recorder)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
