### PR TITLE
fix(check_caret_rclcpp): skip check_caret_rclcpp for ROS Distributions after iron

### DIFF
--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -71,7 +71,7 @@ class RclcppCheck():
 
     def __init__(self, root_dir_path: str) -> None:
         RclcppCheck._ensure_dir_exist(root_dir_path)
-        RclcppCheck._validate_ros_distrinution(root_dir_path)
+        RclcppCheck._validate_ros_distribution(root_dir_path)
 
         get_package_name = RclcppCheck._create_get_package_name(root_dir_path)
         ros_obj_paths = RclcppCheck._get_obj_paths(root_dir_path)
@@ -173,7 +173,7 @@ class RclcppCheck():
         exit(1)
 
     @staticmethod
-    def _validate_ros_distrinution(path: str):
+    def _validate_ros_distribution(path: str):
         if os.environ['ROS_DISTRO'][0] < 'i':
             return
         logger.info('If you are using a ROS distribution after iron, ' \

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -71,6 +71,7 @@ class RclcppCheck():
 
     def __init__(self, root_dir_path: str) -> None:
         RclcppCheck._ensure_dir_exist(root_dir_path)
+        RclcppCheck._validate_ros_distrinution(root_dir_path)
 
         get_package_name = RclcppCheck._create_get_package_name(root_dir_path)
         ros_obj_paths = RclcppCheck._get_obj_paths(root_dir_path)
@@ -170,6 +171,16 @@ class RclcppCheck():
                      'Specify the path to the workspace '
                      'where the build command completed.')
         exit(1)
+
+    @staticmethod
+    def _validate_ros_distrinution(path: str):
+        if os.environ['ROS_DISTRO'][0] < 'i':
+            return
+        logger.info('For ROS Distributions after iron, '
+                    'applications can be evaluated '
+                    'without building with caret-rclcpp. '
+                    'For this reason, the verification procedure is skipped.')
+        exit(0)
 
     @staticmethod
     def get_package_name_from_path(root_dir_path: str, path: str) -> str:

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -174,11 +174,11 @@ class RclcppCheck():
 
     @staticmethod
     def _validate_ros_distribution(path: str):
-        if os.environ['ROS_DISTRO'][0] < 'i':
+        distribution = os.environ['ROS_DISTRO']
+        if distribution[0] < 'i':
             return
-        logger.info('If you are using a ROS distribution after iron, '
-                    'you no longer need to rebuild with caret-rclcpp. '
-                    'Thus, there is no need to validate the workspace.')
+        logger.info('There is no need to build packages '
+                    f'using caret-rclcpp under ROS 2 {distribution}.')
         exit(0)
 
     @staticmethod

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -176,8 +176,8 @@ class RclcppCheck():
     def _validate_ros_distribution(path: str):
         if os.environ['ROS_DISTRO'][0] < 'i':
             return
-        logger.info('If you are using a ROS distribution after iron, ' \
-                    'you no longer need to rebuild with caret-rclcpp. ' \
+        logger.info('If you are using a ROS distribution after iron, '
+                    'you no longer need to rebuild with caret-rclcpp. '
                     'Thus, there is no need to validate the workspace.')
         exit(0)
 

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -176,10 +176,9 @@ class RclcppCheck():
     def _validate_ros_distrinution(path: str):
         if os.environ['ROS_DISTRO'][0] < 'i':
             return
-        logger.info('For ROS Distributions after iron, '
-                    'applications can be evaluated '
-                    'without building with caret-rclcpp. '
-                    'For this reason, the verification procedure is skipped.')
+        logger.info('If you are using a ROS distribution after iron, ' \
+                    'you no longer need to rebuild with caret-rclcpp. ' \
+                    'Thus, there is no need to validate the workspace.')
         exit(0)
 
     @staticmethod

--- a/test/verb/test_check_caret_rclcpp.py
+++ b/test/verb/test_check_caret_rclcpp.py
@@ -84,4 +84,4 @@ class TestCheckCaretRclcpp:
             RclcppCheck('')
         except SystemExit:
             assert len(caplog.records) == 1
-            assert 'there is no need to validate the workspace.' in caplog.messages[0]
+            assert f'There is no need to build packages using caret-rclcpp under ROS 2 iron.' in caplog.messages[0]

--- a/test/verb/test_check_caret_rclcpp.py
+++ b/test/verb/test_check_caret_rclcpp.py
@@ -84,4 +84,5 @@ class TestCheckCaretRclcpp:
             RclcppCheck('')
         except SystemExit:
             assert len(caplog.records) == 1
-            assert f'There is no need to build packages using caret-rclcpp under ROS 2 iron.' in caplog.messages[0]
+            assert 'There is no need to build packages ' \
+                'using caret-rclcpp under ROS 2 iron.' in caplog.messages[0]

--- a/test/verb/test_check_caret_rclcpp.py
+++ b/test/verb/test_check_caret_rclcpp.py
@@ -21,6 +21,8 @@ class TestCheckCaretRclcpp:
 
     def test_file_exist(self, caplog, mocker):
         mocker.patch('os.path.exists', return_value=True)
+        mocker.patch('ros2caret.verb.check_caret_rclcpp.RclcppCheck._validate_ros_distribution',
+                     return_value=None)
         mocker.patch(
             'ros2caret.verb.check_caret_rclcpp.RclcppCheck._get_obj_paths', return_value=[])
         RclcppCheck('')
@@ -30,6 +32,8 @@ class TestCheckCaretRclcpp:
 
     def test_ng_case(self, caplog, mocker):
         mocker.patch('os.path.exists', return_value=True)
+        mocker.patch('ros2caret.verb.check_caret_rclcpp.RclcppCheck._validate_ros_distribution',
+                     return_value=None)
         base_path = 'ros2caret.verb.check_caret_rclcpp.RclcppCheck.'
         mocker.patch(base_path+'_get_obj_paths', return_value=[''])
         mocker.patch(base_path+'_has_caret_rclcpp_tp', return_value=False)
@@ -40,6 +44,8 @@ class TestCheckCaretRclcpp:
         assert record.levelno == WARNING
 
     def test_ok_case(self, caplog, mocker):
+        mocker.patch('ros2caret.verb.check_caret_rclcpp.RclcppCheck._validate_ros_distribution',
+                     return_value=None)
         mocker.patch('os.path.exists', return_value=True)
         base_path = 'ros2caret.verb.check_caret_rclcpp.RclcppCheck.'
         mocker.patch(base_path+'_get_obj_paths', return_value=[''])
@@ -69,3 +75,13 @@ class TestCheckCaretRclcpp:
 
         get_package_name = RclcppCheck._create_get_package_name('foo/bar/')
         assert get_package_name('foo/bar/baz') == 'baz'
+
+    def test_validate_ros_distribution(self, mocker, caplog):
+        mocker.patch('os.path.exists', return_value=True)
+        mocker.patch.dict('os.environ', {'ROS_DISTRO': 'iron'})
+
+        try:
+            RclcppCheck('')
+        except SystemExit:
+            assert len(caplog.records) == 1
+            assert 'there is no need to validate the workspace.' in caplog.messages[0]


### PR DESCRIPTION

## Description

<!-- Write a brief description of this PR. -->

In humble, application is need to rebuild with caret-rclcpp when traceing and evaluating the data.
After iron some trace points have been added to the ros2-caret, therefore it is no longer necessary to check if you are building with caret-rclcpp.
If a build validation command `ros2 caret check_caret_rclcpp` is performed, the process is skipped and and exit successfully.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->


## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
