### PR TITLE
feat: enable sim_time trace point in light mode

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -171,7 +171,8 @@ class RecordVerb(VerbExtension):
                     'ros2_caret:dds_bind*',
                     'ros2:rcl_*init',
                     'ros2_caret:rcl_*init',
-                    'ros2_caret:caret_init']
+                    'ros2_caret:caret_init',
+                    'ros2_caret:sim_time']
             if os.environ['ROS_DISTRO'] in ['iron' or 'rolling']:
                 events_ust.append('ros2:rcl_publish')
         else:


### PR DESCRIPTION
## Description

When the "--light" option is specified in the caret trace command, sim_time is added to the trace points.

## Related links

[https://tier4.atlassian.net/browse/RT2-1083](https://tier4.atlassian.net/browse/RT2-1083)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
