### PR TITLE
refactor: improvement of ros distribution determination method

### DIFF
--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -104,7 +104,7 @@ def init(
 
     if not immediate:
         input('press enter to start...')
-    # for iron, rolling
+    # for ROS Distributions after iron
     if os.environ['ROS_DISTRO'][0] >= 'i':
         trace_directory = lttng.lttng_init(
             session_name=session_name,

--- a/ros2caret/verb/caret_record_init.py
+++ b/ros2caret/verb/caret_record_init.py
@@ -105,7 +105,7 @@ def init(
     if not immediate:
         input('press enter to start...')
     # for iron, rolling
-    if os.environ['ROS_DISTRO'] in ['iron', 'rolling']:
+    if os.environ['ROS_DISTRO'][0] >= 'i':
         trace_directory = lttng.lttng_init(
             session_name=session_name,
             base_path=base_path,

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -194,7 +194,8 @@ class RecordVerb(VerbExtension):
         else:
             init_args['context_fields'] = context_names
         init_args['display_list'] = args.list
-        # Note: keyword argument --subbuffer_size_ust/kernel are available after iron.
+        # Note: keyword argument
+        # --subbuffer_size_ust/kernel are available in ROS Distributions after iron.
 
         if os.environ['ROS_DISTRO'][0] < 'i' \
                 and args.subbuffer_size_ust != 8*4096:

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -194,7 +194,7 @@ class RecordVerb(VerbExtension):
         else:
             init_args['context_fields'] = context_names
         init_args['display_list'] = args.list
-        # Note: keyword argument --subbuffer_size_ust/kernel are available in ROS Distributions after iron.
+        # Note: keyword argument --subbuffer_size_ust/kernel are available after iron.
 
         if os.environ['ROS_DISTRO'][0] < 'i' \
                 and args.subbuffer_size_ust != 8*4096:

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -141,13 +141,13 @@ class RecordVerb(VerbExtension):
             default=8*4096,
             help='the size of the subbuffers for userspace events(default: 8*4096). '
                  'buffer size must be power of two. '
-                 'available in iron or rolling only. ')
+                 'available in ROS Distributions after iron. ')
         parser.add_argument(
             '--subbuffer-size-kernel', dest='subbuffer_size_kernel', type=int,
             default=32*4096,
             help='the size of the subbuffers for kernel events(default: 32*4096). '
                  'buffer size must be power of two. '
-                 'available in iron or rolling only. ')
+                 'available in ROS Distributions after iron. ')
         parser.add_argument(
             '--immediate', dest='immediate', action='store_true',
             help='record immediately. ')
@@ -194,12 +194,12 @@ class RecordVerb(VerbExtension):
         else:
             init_args['context_fields'] = context_names
         init_args['display_list'] = args.list
-        # Note: keyword argument --subbuffer_size_ust/kernel are available in iron or rolling.
+        # Note: keyword argument --subbuffer_size_ust/kernel are available in ROS Distributions after iron.
 
         if os.environ['ROS_DISTRO'][0] < 'i' \
                 and args.subbuffer_size_ust != 8*4096:
             raise ValueError('the --subbuffer-size-ust option is '
-                             'available in iron or rolling')
+                             'available in ROS Distributions after iron')
         if args.subbuffer_size_ust & (args.subbuffer_size_ust-1):
             raise ValueError('--subbuffer-size-ust value must be power of two.')
         init_args['subbuffer_size_ust'] = args.subbuffer_size_ust
@@ -207,7 +207,7 @@ class RecordVerb(VerbExtension):
         if os.environ['ROS_DISTRO'][0] < 'i' \
                 and args.subbuffer_size_kernel != 32*4096:
             raise ValueError('the --subbuffer-size-kernel option is '
-                             'available in iron or rolling')
+                             'available in ROS Distributions after iron')
         if args.subbuffer_size_kernel & (args.subbuffer_size_kernel-1):
             raise ValueError('--subbuffer-size-kernel value must be power of two.')
         init_args['subbuffer_size_kernel'] = args.subbuffer_size_kernel

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -173,7 +173,7 @@ class RecordVerb(VerbExtension):
                     'ros2_caret:rcl_*init',
                     'ros2_caret:caret_init',
                     'ros2_caret:sim_time']
-            if os.environ['ROS_DISTRO'] in ['iron' or 'rolling']:
+            if os.environ['ROS_DISTRO'][0] >= 'i':
                 events_ust.append('ros2:rcl_publish')
         else:
             events_ust = ['ros*']
@@ -196,7 +196,7 @@ class RecordVerb(VerbExtension):
         init_args['display_list'] = args.list
         # Note: keyword argument --subbuffer_size_ust/kernel are available in iron or rolling.
 
-        if os.environ['ROS_DISTRO'] not in ['iron', 'rolling'] \
+        if os.environ['ROS_DISTRO'][0] < 'i' \
                 and args.subbuffer_size_ust != 8*4096:
             raise ValueError('the --subbuffer-size-ust option is '
                              'available in iron or rolling')
@@ -204,7 +204,7 @@ class RecordVerb(VerbExtension):
             raise ValueError('--subbuffer-size-ust value must be power of two.')
         init_args['subbuffer_size_ust'] = args.subbuffer_size_ust
 
-        if os.environ['ROS_DISTRO'] not in ['iron', 'rolling'] \
+        if os.environ['ROS_DISTRO'][0] < 'i' \
                 and args.subbuffer_size_kernel != 32*4096:
             raise ValueError('the --subbuffer-size-kernel option is '
                              'available in iron or rolling')


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Determination method of ROS distribution for iron or rolling replaces to correspond to distribution after iron.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
