### PR TITLE
fix: support environment without std::input to stop recording

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -15,6 +15,7 @@
 import os
 import signal
 import subprocess
+import time
 
 from typing import Optional
 
@@ -27,7 +28,6 @@ from rclpy.node import Node
 from ros2caret.verb import VerbExtension
 from ros2caret.verb.caret_record_init import init
 
-import time
 from tqdm import tqdm
 
 from tracetools_trace.tools import lttng, names, path

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -27,6 +27,7 @@ from rclpy.node import Node
 from ros2caret.verb import VerbExtension
 from ros2caret.verb.caret_record_init import init
 
+import time
 from tqdm import tqdm
 
 from tracetools_trace.tools import lttng, names, path
@@ -219,7 +220,12 @@ class RecordVerb(VerbExtension):
             recordable_node_num = node.start(args.verbose, args.recording_frequency)
             while not node.started and recordable_node_num > 0:
                 rclpy.spin_once(node)
-            input('press enter to stop...')
+            try:
+                input('press enter to stop...')
+            except EOFError:
+                print('\nstd::input is not supported in this system. press ctrl-c to stop...')
+                while True:
+                    time.sleep(10)
 
         def _fini():
             node.stop_progress()


### PR DESCRIPTION
## Description

- `ros2 caret record --immediate` option had been introduced for recording without keyboard input. In this case, ctrl-c is expected to stop recording.
- However, `input` operation causes exception on environment without standard input, which causes the following errors.

```
Traceback (most recent call last):
  File "/opt/ros/humble/bin/ros2", line 33, in <module>
    sys.exit(load_entry_point('ros2cli==0.18.7', 'console_scripts', 'ros2')())
  File "/opt/ros/humble/lib/python3.10/site-packages/ros2cli/cli.py", line 89, in main
    rc = extension.main(parser=parser, args=args)
  File "/home/takeshiiwanari/ros2_caret_ws/build/ros2caret/ros2caret/command/caret.py", line 32, in main
    return extension.main(args=args)
  File "/home/takeshiiwanari/ros2_caret_ws/build/ros2caret/ros2caret/verb/record.py", line 240, in main
    execute_and_handle_sigint(_run, _fini)
  File "/home/takeshiiwanari/ros2_caret_ws/build/tracetools_trace/tracetools_trace/tools/signals.py", line 114, in execute_and_handle_sigint
    run_function()
  File "/home/takeshiiwanari/ros2_caret_ws/build/ros2caret/ros2caret/verb/record.py", line 222, in _run
    input('press enter to stop...')
EOFError: EOF when reading a line
```

## Related links

[TIER IV Internal link](https://tier4.atlassian.net/browse/RT2-1244)

## Notes for reviewers

Command to test

```
ros2 caret record --immediate < /dev/null
```


## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
