### PR TITLE
fix: ignore caret package on workflow pytest

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -24,6 +24,9 @@ jobs:
         run: |
           . /opt/ros/humble/setup.sh
           rosdep update
+          # Not install caret packages in buildfarm
+          sed -i '/<depend>caret_analyze<\/depend>/d' package.xml
+          sed -i '/<depend>caret_msgs<\/depend>/d' package.xml
           rosdep install -r -y --from-paths .
         shell: bash
 

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,5 +1,5 @@
 repositories:
-  CARET_analyze:
+  caret_analyze:
     type: git
-    url: https://github.com/tier4/CARET_analyze.git
+    url: https://github.com/tier4/caret_analyze.git
     version: main


### PR DESCRIPTION
## Description
Because caret packages was added ROS buildfarm, `rosdep install` find caret packages and install error. 
modified `rosdep install` don't refer caret pacages.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
