### PR TITLE
fix: add max_construction_order to the command line argument

### DIFF
--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -164,7 +164,7 @@ class RclcppCheck():
 
     @staticmethod
     def _ensure_dir_exist(path: str):
-        if(os.path.exists(path)):
+        if os.path.exists(path):
             return
 
         logger.error('"build" directory not found. '

--- a/ros2caret/verb/check_caret_rclcpp.py
+++ b/ros2caret/verb/check_caret_rclcpp.py
@@ -164,7 +164,7 @@ class RclcppCheck():
 
     @staticmethod
     def _ensure_dir_exist(path: str):
-        if os.path.exists(path):
+        if(os.path.exists(path)):
             return
 
         logger.error('"build" directory not found. '

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -30,13 +30,13 @@ class CheckCTFVerb(VerbExtension):
             help='the path to the trace directory to be checked')
         parser.add_argument(
             '-m', '--max_construction_order', dest='max_construction_order', type=int, 
-            help='max construction order. The value must be positive integer.',
+            help='max construction order. The value must be positive integer."0" is unlimited.',
             required=False, default=None)
 
     def main(self, *, args):
         try:
             if args.max_construction_order is not None:
-                if args.max_construction_order > 0:
+                if args.max_construction_order >= 0:
                     Lttng(args.trace_dir)
                     Architecture('lttng', 
                                  args.trace_dir, 

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -38,14 +38,20 @@ class CheckCTFVerb(VerbExtension):
         try:
             if args.max_callback_construction_order_on_path_searching is not None:
                 if args.max_callback_construction_order_on_path_searching >= 0:
+                    tmp = args.max_callback_construction_order_on_path_searching
                     Lttng(args.trace_dir)
-                    Architecture('lttng',
-                                 args.trace_dir,
-                                 max_callback_construction_order_on_path_searching=args.max_callback_construction_order_on_path_searching)
+                    Architecture(
+                        'lttng',
+                        args.trace_dir,
+                        max_callback_construction_order_on_path_searching=tmp
+                    )
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_callback_construction_order_on_path_searching (%s)'
-                        % args.max_callback_construction_order_on_path_searching)
+                        'error: argument',
+                        '-m/--max_callback_construction_order_on_path_searching',
+                        '(%s)' % args.max_callback_construction_order_on_path_searching
+                    )
+
             else:
                 Lttng(args.trace_dir)
                 Architecture('lttng', args.trace_dir)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -15,8 +15,7 @@
 
 from logging import getLogger
 
-from caret_analyze import Architecture, Lttng
-from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze import Architecture, Lttng, MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -15,7 +15,7 @@
 
 from logging import getLogger
 
-from caret_analyze import Architecture, Lttng, MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze import Architecture, Lttng, DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)
@@ -34,7 +34,7 @@ class CheckCTFVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+            required=False, default=DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -16,7 +16,8 @@
 from logging import getLogger
 
 from caret_analyze import Architecture, Lttng
-from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze.architecture.architecture import \
+    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -16,7 +16,6 @@
 from logging import getLogger
 
 from caret_analyze import Architecture, Lttng
-from caret_analyze.exceptions import Error
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)
@@ -29,8 +28,8 @@ class CheckCTFVerb(VerbExtension):
             'trace_dir', type=str,
             help='the path to the trace directory to be checked')
         parser.add_argument(
-            '-m', '--max_construction_order', dest='max_construction_order', type=int, 
-            help='max construction order. The value must be positive integer."0" is unlimited.',
+            '-m', '--max_construction_order', dest='max_construction_order', type=int,
+            help='max construction order. The value must be positive integer. "0" is unlimited.',
             required=False, default=None)
 
     def main(self, *, args):
@@ -38,12 +37,12 @@ class CheckCTFVerb(VerbExtension):
             if args.max_construction_order is not None:
                 if args.max_construction_order >= 0:
                     Lttng(args.trace_dir)
-                    Architecture('lttng', 
-                                 args.trace_dir, 
+                    Architecture('lttng',
+                                 args.trace_dir,
                                  max_construction_order=args.max_construction_order)
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_construction_order (%s)' 
+                        'error: argument -m/--max_construction_order (%s)'
                         % args.max_construction_order)
             else:
                 Lttng(args.trace_dir)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -30,7 +30,7 @@ class CheckCTFVerb(VerbExtension):
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
             type=int, dest='max_construction_order',
-            help='max construction order order on path searching.'
+            help='max construction order on path searching.'
                  'The value must be positive integer. "0" is unlimited.',
             required=False, default=None)
 

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -16,6 +16,7 @@
 from logging import getLogger
 
 from caret_analyze import Architecture, Lttng
+from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)
@@ -30,30 +31,27 @@ class CheckCTFVerb(VerbExtension):
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
             type=int, dest='max_callback_construction_order_on_path_searching',
-            help='max construction order on path searching.'
-                 'The value must be positive integer. "0" is unlimited.',
-            required=False, default=None)
+            help='callbacks whose construction_order are greater than'
+            ' this value are ignored on path searching.'
+            ' The value must be positive integer or "0". "0" means unlimited.'
+            ' Default: %(default)s',
+            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+        )
 
     def main(self, *, args):
         try:
-            if args.max_callback_construction_order_on_path_searching is not None:
-                if args.max_callback_construction_order_on_path_searching >= 0:
-                    tmp = args.max_callback_construction_order_on_path_searching
-                    Lttng(args.trace_dir)
-                    Architecture(
-                        'lttng',
-                        args.trace_dir,
-                        max_callback_construction_order_on_path_searching=tmp
-                    )
-                else:
-                    raise ValueError(
-                        'error: argument',
-                        '-m/--max_callback_construction_order_on_path_searching',
-                        '(%s)' % args.max_callback_construction_order_on_path_searching
-                    )
-
-            else:
+            if args.max_callback_construction_order_on_path_searching >= 0:
                 Lttng(args.trace_dir)
-                Architecture('lttng', args.trace_dir)
+                Architecture(
+                    'lttng',
+                    args.trace_dir,
+                    args.max_callback_construction_order_on_path_searching
+                )
+            else:
+                raise ValueError(
+                    'error: argument',
+                    '-m/--max_callback_construction_order_on_path_searching',
+                    '(%s)' % args.max_callback_construction_order_on_path_searching
+                )
         except Exception as e:
             logger.warning(e)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -28,10 +28,25 @@ class CheckCTFVerb(VerbExtension):
         parser.add_argument(
             'trace_dir', type=str,
             help='the path to the trace directory to be checked')
+        parser.add_argument(
+            '-m', '--max_construction_order', dest='max_construction_order', type=int, 
+            help='max construction order. The value must be positive integer.',
+            required=False, default=None)
 
     def main(self, *, args):
         try:
-            Lttng(args.trace_dir)
-            Architecture('lttng', args.trace_dir)
-        except Error as e:
+            if args.max_construction_order is not None:
+                if args.max_construction_order > 0:
+                    Lttng(args.trace_dir)
+                    Architecture('lttng', 
+                                 args.trace_dir, 
+                                 max_construction_order=args.max_construction_order)
+                else:
+                    raise ValueError(
+                        'error: argument -m/--max_construction_order (%s)' 
+                        % args.max_construction_order)
+            else:
+                Lttng(args.trace_dir)
+                Architecture('lttng', args.trace_dir)
+        except Exception as e:
             logger.warning(e)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -15,7 +15,9 @@
 
 from logging import getLogger
 
-from caret_analyze import Architecture, Lttng, DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze import (Architecture,
+                           DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                           Lttng)
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -28,8 +28,10 @@ class CheckCTFVerb(VerbExtension):
             'trace_dir', type=str,
             help='the path to the trace directory to be checked')
         parser.add_argument(
-            '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer. "0" is unlimited.',
+            '-m', '--max_callback_construction_order_on_path_searching',
+            type=int, dest='max_construction_order',
+            help='max construction order order on path searching.'
+                 'The value must be positive integer. "0" is unlimited.',
             required=False, default=None)
 
     def main(self, *, args):

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -29,23 +29,23 @@ class CheckCTFVerb(VerbExtension):
             help='the path to the trace directory to be checked')
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
-            type=int, dest='max_construction_order',
+            type=int, dest='max_callback_construction_order_on_path_searching',
             help='max construction order on path searching.'
                  'The value must be positive integer. "0" is unlimited.',
             required=False, default=None)
 
     def main(self, *, args):
         try:
-            if args.max_construction_order is not None:
-                if args.max_construction_order >= 0:
+            if args.max_callback_construction_order_on_path_searching is not None:
+                if args.max_callback_construction_order_on_path_searching >= 0:
                     Lttng(args.trace_dir)
                     Architecture('lttng',
                                  args.trace_dir,
-                                 max_construction_order=args.max_construction_order)
+                                 max_callback_construction_order_on_path_searching=args.max_callback_construction_order_on_path_searching)
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_construction_order (%s)'
-                        % args.max_construction_order)
+                        'error: argument -m/--max_callback_construction_order_on_path_searching (%s)'
+                        % args.max_callback_construction_order_on_path_searching)
             else:
                 Lttng(args.trace_dir)
                 Architecture('lttng', args.trace_dir)

--- a/ros2caret/verb/check_ctf.py
+++ b/ros2caret/verb/check_ctf.py
@@ -16,8 +16,7 @@
 from logging import getLogger
 
 from caret_analyze import Architecture, Lttng
-from caret_analyze.architecture.architecture import \
-    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 logger = getLogger(__name__)

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -69,7 +69,7 @@ class CreateArchitectureVerb(VerbExtension):
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
             type=int, dest='max_construction_order',
-            help='max construction order order on path searching.'
+            help='max construction order on path searching.'
                  'The value must be positive integer. "0" is unlimited.',
             required=False, default=None
         )

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -49,6 +49,9 @@ logger = getLogger(__name__)
 logger.setLevel(INFO)
 logger.addHandler(handler)
 
+max_callback_construction_order_on_path_searching = \
+    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+
 
 class CreateArchitectureVerb(VerbExtension):
 
@@ -74,7 +77,7 @@ class CreateArchitectureVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+            required=False, default=max_callback_construction_order_on_path_searching,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 try:
     import caret_analyze
-    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+    from caret_analyze import DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
     Architecture = caret_analyze.Architecture
     Error = caret_analyze.exceptions.Error
     CatchErrors = (OSError, Error)
@@ -74,7 +74,7 @@ class CreateArchitectureVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+            required=False, default=DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -67,8 +67,10 @@ class CreateArchitectureVerb(VerbExtension):
             required=False, default=False
         )
         parser.add_argument(
-            '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer. "0" is unlimited.',
+            '-m', '--max_callback_construction_order_on_path_searching',
+            type=int, dest='max_construction_order',
+            help='max construction order order on path searching.'
+                 'The value must be positive integer. "0" is unlimited.',
             required=False, default=None
         )
 

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -29,7 +29,8 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze.architecture.architecture import \
+    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -76,7 +76,10 @@ class CreateArchitectureVerb(VerbExtension):
 
     def main(self, *, args):
         try:
-            create_arch = CreateArchitecture(args.trace_dir, args.max_callback_construction_order_on_path_searching)
+            create_arch = CreateArchitecture(
+                args.trace_dir,
+                args.max_callback_construction_order_on_path_searching
+            )
             create_arch.create(args.output_path, args.force)
         except Exception as e:
             logger.warning(e)
@@ -97,13 +100,18 @@ class CreateArchitecture:
         else:
             if max_callback_construction_order_on_path_searching is not None:
                 if max_callback_construction_order_on_path_searching >= 0:
-                    self._arch = Architecture('lttng',
-                                              trace_dir,
-                                              max_callback_construction_order_on_path_searching=max_callback_construction_order_on_path_searching)
+                    tmp = max_callback_construction_order_on_path_searching
+                    self._arch = Architecture(
+                        'lttng',
+                        trace_dir,
+                        max_callback_construction_order_on_path_searching=tmp
+                    )
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_callback_construction_order_on_path_searching (%s)'
-                        % max_callback_construction_order_on_path_searching)
+                        'error: argument',
+                        '-m/--max_callback_construction_order_on_path_searching',
+                        '(%s)' % max_callback_construction_order_on_path_searching
+                    )
             else:
                 self._arch = Architecture('lttng', trace_dir)
 

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -86,8 +86,6 @@ class CreateArchitectureVerb(VerbExtension):
             create_arch.create(args.output_path, args.force)
         except Exception as e:
             logger.warning(e)
-            return 1
-        return 0
 
 
 class CreateArchitecture:
@@ -102,11 +100,10 @@ class CreateArchitecture:
             self._arch = architecture
         else:
             if max_callback_construction_order_on_path_searching >= 0:
-                tmp = max_callback_construction_order_on_path_searching
                 self._arch = Architecture(
                     'lttng',
                     trace_dir,
-                    max_callback_construction_order_on_path_searching=tmp
+                    max_callback_construction_order_on_path_searching
                 )
             else:
                 raise ValueError(

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -27,8 +27,9 @@ except ModuleNotFoundError as e:
         Architecture = None
         CatchErrors = OSError
     else:
-        raise e
+        raise(e)
 
+from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 
@@ -69,9 +70,11 @@ class CreateArchitectureVerb(VerbExtension):
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
             type=int, dest='max_callback_construction_order_on_path_searching',
-            help='max construction order on path searching.'
-                 'The value must be positive integer. "0" is unlimited.',
-            required=False, default=None
+            help='callbacks whose construction_order are greater than'
+            ' this value are ignored on path searching.'
+            ' The value must be positive integer or "0". "0" means unlimited.'
+            ' Default: %(default)s',
+            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):
@@ -98,22 +101,19 @@ class CreateArchitecture:
         if architecture:
             self._arch = architecture
         else:
-            if max_callback_construction_order_on_path_searching is not None:
-                if max_callback_construction_order_on_path_searching >= 0:
-                    tmp = max_callback_construction_order_on_path_searching
-                    self._arch = Architecture(
-                        'lttng',
-                        trace_dir,
-                        max_callback_construction_order_on_path_searching=tmp
-                    )
-                else:
-                    raise ValueError(
-                        'error: argument',
-                        '-m/--max_callback_construction_order_on_path_searching',
-                        '(%s)' % max_callback_construction_order_on_path_searching
-                    )
+            if max_callback_construction_order_on_path_searching >= 0:
+                tmp = max_callback_construction_order_on_path_searching
+                self._arch = Architecture(
+                    'lttng',
+                    trace_dir,
+                    max_callback_construction_order_on_path_searching=tmp
+                )
             else:
-                self._arch = Architecture('lttng', trace_dir)
+                raise ValueError(
+                    'error: argument',
+                    '-m/--max_callback_construction_order_on_path_searching',
+                    '(%s)' % max_callback_construction_order_on_path_searching
+                )
 
     def create(self, output_path: str, force: bool) -> None:
         try:

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 try:
     import caret_analyze
+    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
     Architecture = caret_analyze.Architecture
     Error = caret_analyze.exceptions.Error
     CatchErrors = (OSError, Error)
@@ -29,7 +30,6 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 
@@ -48,9 +48,6 @@ root_logger.removeHandler(root_logger.handlers[0])
 logger = getLogger(__name__)
 logger.setLevel(INFO)
 logger.addHandler(handler)
-
-max_callback_construction_order_on_path_searching = \
-    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 
 
 class CreateArchitectureVerb(VerbExtension):
@@ -77,7 +74,7 @@ class CreateArchitectureVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=max_callback_construction_order_on_path_searching,
+            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -68,7 +68,7 @@ class CreateArchitectureVerb(VerbExtension):
         )
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
-            type=int, dest='max_construction_order',
+            type=int, dest='max_callback_construction_order_on_path_searching',
             help='max construction order on path searching.'
                  'The value must be positive integer. "0" is unlimited.',
             required=False, default=None
@@ -76,7 +76,7 @@ class CreateArchitectureVerb(VerbExtension):
 
     def main(self, *, args):
         try:
-            create_arch = CreateArchitecture(args.trace_dir, args.max_construction_order)
+            create_arch = CreateArchitecture(args.trace_dir, args.max_callback_construction_order_on_path_searching)
             create_arch.create(args.output_path, args.force)
         except Exception as e:
             logger.warning(e)
@@ -89,21 +89,21 @@ class CreateArchitecture:
     def __init__(
         self,
         trace_dir: str,
-        max_construction_order: int,
+        max_callback_construction_order_on_path_searching: int,
         architecture: Optional[Architecture] = None
     ) -> None:
         if architecture:
             self._arch = architecture
         else:
-            if max_construction_order is not None:
-                if max_construction_order >= 0:
+            if max_callback_construction_order_on_path_searching is not None:
+                if max_callback_construction_order_on_path_searching >= 0:
                     self._arch = Architecture('lttng',
                                               trace_dir,
-                                              max_construction_order=max_construction_order)
+                                              max_callback_construction_order_on_path_searching=max_callback_construction_order_on_path_searching)
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_construction_order (%s)'
-                        % max_construction_order)
+                        'error: argument -m/--max_callback_construction_order_on_path_searching (%s)'
+                        % max_callback_construction_order_on_path_searching)
             else:
                 self._arch = Architecture('lttng', trace_dir)
 

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -68,7 +68,7 @@ class CreateArchitectureVerb(VerbExtension):
         )
         parser.add_argument(
             '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer.',
+            help='max construction order. The value must be positive integer."0" is unlimited.',
             required=False, default=None
         )
 
@@ -94,7 +94,7 @@ class CreateArchitecture:
             self._arch = architecture
         else:
             if max_construction_order is not None:
-                if max_construction_order > 0:
+                if max_construction_order >~ 0:
                     self._arch = Architecture('lttng', 
                                               trace_dir, 
                                               max_construction_order=max_construction_order)

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -27,7 +27,7 @@ except ModuleNotFoundError as e:
         Architecture = None
         CatchErrors = OSError
     else:
-        raise(e)
+        raise e
 
 from ros2caret.verb import VerbExtension
 
@@ -68,7 +68,7 @@ class CreateArchitectureVerb(VerbExtension):
         )
         parser.add_argument(
             '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer."0" is unlimited.',
+            help='max construction order. The value must be positive integer. "0" is unlimited.',
             required=False, default=None
         )
 
@@ -94,13 +94,13 @@ class CreateArchitecture:
             self._arch = architecture
         else:
             if max_construction_order is not None:
-                if max_construction_order >~ 0:
-                    self._arch = Architecture('lttng', 
-                                              trace_dir, 
+                if max_construction_order >= 0:
+                    self._arch = Architecture('lttng',
+                                              trace_dir,
                                               max_construction_order=max_construction_order)
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_construction_order (%s)' 
+                        'error: argument -m/--max_construction_order (%s)'
                         % max_construction_order)
             else:
                 self._arch = Architecture('lttng', trace_dir)

--- a/ros2caret/verb/create_architecture.py
+++ b/ros2caret/verb/create_architecture.py
@@ -29,8 +29,7 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze.architecture.architecture import \
-    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -58,7 +58,7 @@ class VerifyPathsVerb(VerbExtension):
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
             type=int, dest='max_construction_order',
-            help='max construction order order on path searching.'
+            help='max construction order on path searching.'
                  'The value must be positive integer. "0" is unlimited.',
             required=False, default=None
         )

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -73,8 +73,6 @@ class VerifyPathsVerb(VerbExtension):
             verify_paths.verify(args.verified_path_names)
         except Exception as e:
             logger.info(e)
-            return 1
-        return 0
 
 
 class VerifyPaths:

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -65,7 +65,8 @@ class VerifyPathsVerb(VerbExtension):
 
     def main(self, *, args):
         try:
-            verify_paths = VerifyPaths(args.arch_path, args.max_callback_construction_order_on_path_searching)
+            verify_paths = VerifyPaths(args.arch_path,
+                                       args.max_callback_construction_order_on_path_searching)
             verify_paths.verify(args.verified_path_names)
         except Exception as e:
             logger.info(e)
@@ -86,13 +87,18 @@ class VerifyPaths:
         else:
             if max_callback_construction_order_on_path_searching is not None:
                 if max_callback_construction_order_on_path_searching >= 0:
-                    self._arch = Architecture('yaml',
-                                              arch_path,
-                                              max_callback_construction_order_on_path_searching=max_callback_construction_order_on_path_searching)
+                    tmp = max_callback_construction_order_on_path_searching
+                    self._arch = Architecture(
+                        'yaml',
+                        arch_path,
+                        max_callback_construction_order_on_path_searching=tmp
+                    )
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_callback_construction_order_on_path_searching (%s)'
-                        % max_callback_construction_order_on_path_searching)
+                        'error: argument',
+                        '-m/--max_callback_construction_order_on_path_searching',
+                        '(%s)' % max_callback_construction_order_on_path_searching
+                    )
             else:
                 self._arch = Architecture('yaml', arch_path)
 

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -42,6 +42,9 @@ logger = getLogger(__name__)
 logger.setLevel(INFO)
 logger.addHandler(handler)
 
+max_callback_construction_order_on_path_searching = \
+    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+
 
 class VerifyPathsVerb(VerbExtension):
 
@@ -63,7 +66,7 @@ class VerifyPathsVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+            required=False, default=max_callback_construction_order_on_path_searching,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -56,8 +56,10 @@ class VerifyPathsVerb(VerbExtension):
             required=False,
         )
         parser.add_argument(
-            '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer. "0" is unlimited.',
+            '-m', '--max_callback_construction_order_on_path_searching',
+            type=int, dest='max_construction_order',
+            help='max construction order order on path searching.'
+                 'The value must be positive integer. "0" is unlimited.',
             required=False, default=None
         )
 

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -57,7 +57,7 @@ class VerifyPathsVerb(VerbExtension):
         )
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
-            type=int, dest='max_construction_order',
+            type=int, dest='max_callback_construction_order_on_path_searching',
             help='max construction order on path searching.'
                  'The value must be positive integer. "0" is unlimited.',
             required=False, default=None
@@ -65,7 +65,7 @@ class VerifyPathsVerb(VerbExtension):
 
     def main(self, *, args):
         try:
-            verify_paths = VerifyPaths(args.arch_path, args.max_construction_order)
+            verify_paths = VerifyPaths(args.arch_path, args.max_callback_construction_order_on_path_searching)
             verify_paths.verify(args.verified_path_names)
         except Exception as e:
             logger.info(e)
@@ -78,21 +78,21 @@ class VerifyPaths:
     def __init__(
         self,
         arch_path: str,
-        max_construction_order: int,
+        max_callback_construction_order_on_path_searching: int,
         architecture: Optional[Architecture] = None
     ) -> None:
         if architecture:
             self._arch = architecture
         else:
-            if max_construction_order is not None:
-                if max_construction_order >= 0:
+            if max_callback_construction_order_on_path_searching is not None:
+                if max_callback_construction_order_on_path_searching >= 0:
                     self._arch = Architecture('yaml',
                                               arch_path,
-                                              max_construction_order=max_construction_order)
+                                              max_callback_construction_order_on_path_searching=max_callback_construction_order_on_path_searching)
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_construction_order (%s)'
-                        % max_construction_order)
+                        'error: argument -m/--max_callback_construction_order_on_path_searching (%s)'
+                        % max_callback_construction_order_on_path_searching)
             else:
                 self._arch = Architecture('yaml', arch_path)
 

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -23,7 +23,7 @@ except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
         Architecture = None
     else:
-        raise(e)
+        raise e
 
 from ros2caret.verb import VerbExtension
 
@@ -57,7 +57,7 @@ class VerifyPathsVerb(VerbExtension):
         )
         parser.add_argument(
             '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer."0" is unlimited.',
+            help='max construction order. The value must be positive integer. "0" is unlimited.',
             required=False, default=None
         )
 
@@ -69,6 +69,7 @@ class VerifyPathsVerb(VerbExtension):
             logger.info(e)
             return 1
         return 0
+
 
 class VerifyPaths:
 
@@ -83,12 +84,12 @@ class VerifyPaths:
         else:
             if max_construction_order is not None:
                 if max_construction_order >= 0:
-                    self._arch = Architecture('yaml', 
-                                              arch_path, 
+                    self._arch = Architecture('yaml',
+                                              arch_path,
                                               max_construction_order=max_construction_order)
                 else:
                     raise ValueError(
-                        'error: argument -m/--max_construction_order (%s)' 
+                        'error: argument -m/--max_construction_order (%s)'
                         % max_construction_order)
             else:
                 self._arch = Architecture('yaml', arch_path)

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 
 try:
     import caret_analyze
-    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+    from caret_analyze import DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
     Architecture = caret_analyze.Architecture
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
@@ -63,7 +63,7 @@ class VerifyPathsVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+            required=False, default=DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -25,7 +25,8 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze.architecture.architecture import \
+    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -18,6 +18,7 @@ from typing import List, Optional
 
 try:
     import caret_analyze
+    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
     Architecture = caret_analyze.Architecture
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
@@ -25,7 +26,6 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 
@@ -41,9 +41,6 @@ handler.setFormatter(formatter)
 logger = getLogger(__name__)
 logger.setLevel(INFO)
 logger.addHandler(handler)
-
-max_callback_construction_order_on_path_searching = \
-    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 
 
 class VerifyPathsVerb(VerbExtension):
@@ -66,7 +63,7 @@ class VerifyPathsVerb(VerbExtension):
             ' this value are ignored on path searching.'
             ' The value must be positive integer or "0". "0" means unlimited.'
             ' Default: %(default)s',
-            required=False, default=max_callback_construction_order_on_path_searching,
+            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -23,8 +23,9 @@ except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
         Architecture = None
     else:
-        raise e
+        raise(e)
 
+from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 
@@ -58,9 +59,11 @@ class VerifyPathsVerb(VerbExtension):
         parser.add_argument(
             '-m', '--max_callback_construction_order_on_path_searching',
             type=int, dest='max_callback_construction_order_on_path_searching',
-            help='max construction order on path searching.'
-                 'The value must be positive integer. "0" is unlimited.',
-            required=False, default=None
+            help='callbacks whose construction_order are greater than'
+            ' this value are ignored on path searching.'
+            ' The value must be positive integer or "0". "0" means unlimited.'
+            ' Default: %(default)s',
+            required=False, default=MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
         )
 
     def main(self, *, args):
@@ -85,22 +88,18 @@ class VerifyPaths:
         if architecture:
             self._arch = architecture
         else:
-            if max_callback_construction_order_on_path_searching is not None:
-                if max_callback_construction_order_on_path_searching >= 0:
-                    tmp = max_callback_construction_order_on_path_searching
-                    self._arch = Architecture(
-                        'yaml',
-                        arch_path,
-                        max_callback_construction_order_on_path_searching=tmp
-                    )
-                else:
-                    raise ValueError(
-                        'error: argument',
-                        '-m/--max_callback_construction_order_on_path_searching',
-                        '(%s)' % max_callback_construction_order_on_path_searching
-                    )
+            if max_callback_construction_order_on_path_searching >= 0:
+                self._arch = Architecture(
+                    'yaml',
+                    arch_path,
+                    max_callback_construction_order_on_path_searching
+                )
             else:
-                self._arch = Architecture('yaml', arch_path)
+                raise ValueError(
+                    'error: argument',
+                    '-m/--max_callback_construction_order_on_path_searching',
+                    '(%s)' % max_callback_construction_order_on_path_searching
+                )
 
     def verify(
         self,

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -57,7 +57,7 @@ class VerifyPathsVerb(VerbExtension):
         )
         parser.add_argument(
             '-m', '--max_construction_order', dest='max_construction_order', type=int,
-            help='max construction order. The value must be positive integer.',
+            help='max construction order. The value must be positive integer."0" is unlimited.',
             required=False, default=None
         )
 
@@ -82,7 +82,7 @@ class VerifyPaths:
             self._arch = architecture
         else:
             if max_construction_order is not None:
-                if max_construction_order > 0:
+                if max_construction_order >= 0:
                     self._arch = Architecture('yaml', 
                                               arch_path, 
                                               max_construction_order=max_construction_order)

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -55,23 +55,43 @@ class VerifyPathsVerb(VerbExtension):
             help='path names to be verified.',
             required=False,
         )
+        parser.add_argument(
+            '-m', '--max_construction_order', dest='max_construction_order', type=int,
+            help='max construction order. The value must be positive integer.',
+            required=False, default=None
+        )
 
     def main(self, *, args):
-        verify_paths = VerifyPaths(args.arch_path)
-        verify_paths.verify(args.verified_path_names)
-
+        try:
+            verify_paths = VerifyPaths(args.arch_path, args.max_construction_order)
+            verify_paths.verify(args.verified_path_names)
+        except Exception as e:
+            logger.info(e)
+            return 1
+        return 0
 
 class VerifyPaths:
 
     def __init__(
         self,
         arch_path: str,
+        max_construction_order: int,
         architecture: Optional[Architecture] = None
     ) -> None:
         if architecture:
             self._arch = architecture
         else:
-            self._arch = Architecture('yaml', arch_path)
+            if max_construction_order is not None:
+                if max_construction_order > 0:
+                    self._arch = Architecture('yaml', 
+                                              arch_path, 
+                                              max_construction_order=max_construction_order)
+                else:
+                    raise ValueError(
+                        'error: argument -m/--max_construction_order (%s)' 
+                        % max_construction_order)
+            else:
+                self._arch = Architecture('yaml', arch_path)
 
     def verify(
         self,

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -25,8 +25,7 @@ except ModuleNotFoundError as e:
     else:
         raise(e)
 
-from caret_analyze.architecture.architecture import \
-    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from caret_analyze.architecture import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb import VerbExtension
 
 

--- a/test/verb/test_create_architecture.py
+++ b/test/verb/test_create_architecture.py
@@ -22,7 +22,7 @@ class TestCreateArchitecture:
     def test_create_success_case(self, caplog, mocker):
         architecture_mock = mocker.Mock()
         mocker.patch.object(architecture_mock, 'export', return_value=None)
-        create_arch = CreateArchitecture('', architecture_mock)
+        create_arch = CreateArchitecture('', 10, architecture_mock)
 
         create_arch.create('output_path', True)
         assert len(caplog.records) == 1
@@ -34,7 +34,7 @@ class TestCreateArchitecture:
         mocker.patch.object(architecture_mock,
                             'export',
                             side_effect=OSError(''))
-        create_arch = CreateArchitecture('', architecture_mock)
+        create_arch = CreateArchitecture('', 10, architecture_mock)
 
         create_arch.create('output_path', True)
         assert len(caplog.records) == 1

--- a/test/verb/test_create_architecture.py
+++ b/test/verb/test_create_architecture.py
@@ -14,7 +14,14 @@
 
 from logging import ERROR, INFO
 
-from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+try:
+    import os
+    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+except ModuleNotFoundError as e:
+    if 'GITHUB_ACTION' in os.environ:
+        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
+    else:
+        raise e
 from ros2caret.verb.create_architecture import CreateArchitecture
 
 

--- a/test/verb/test_create_architecture.py
+++ b/test/verb/test_create_architecture.py
@@ -14,8 +14,8 @@
 
 from logging import ERROR, INFO
 
-from ros2caret.verb.create_architecture import (CreateArchitecture,
-                                                max_callback_construction_order_on_path_searching)
+from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from ros2caret.verb.create_architecture import CreateArchitecture
 
 
 class TestCreateArchitecture:
@@ -24,7 +24,7 @@ class TestCreateArchitecture:
         architecture_mock = mocker.Mock()
         mocker.patch.object(architecture_mock, 'export', return_value=None)
         create_arch = CreateArchitecture('',
-                                         max_callback_construction_order_on_path_searching,
+                                         MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                          architecture_mock)
 
         create_arch.create('output_path', True)
@@ -38,7 +38,7 @@ class TestCreateArchitecture:
                             'export',
                             side_effect=OSError(''))
         create_arch = CreateArchitecture('',
-                                         max_callback_construction_order_on_path_searching,
+                                         MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                          architecture_mock)
 
         create_arch.create('output_path', True)

--- a/test/verb/test_create_architecture.py
+++ b/test/verb/test_create_architecture.py
@@ -16,10 +16,10 @@ from logging import ERROR, INFO
 
 try:
     import os
-    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+    from caret_analyze import DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
-        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
+        DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
     else:
         raise e
 from ros2caret.verb.create_architecture import CreateArchitecture
@@ -31,7 +31,7 @@ class TestCreateArchitecture:
         architecture_mock = mocker.Mock()
         mocker.patch.object(architecture_mock, 'export', return_value=None)
         create_arch = CreateArchitecture('',
-                                         MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                         DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                          architecture_mock)
 
         create_arch.create('output_path', True)
@@ -45,7 +45,7 @@ class TestCreateArchitecture:
                             'export',
                             side_effect=OSError(''))
         create_arch = CreateArchitecture('',
-                                         MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                         DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                          architecture_mock)
 
         create_arch.create('output_path', True)

--- a/test/verb/test_create_architecture.py
+++ b/test/verb/test_create_architecture.py
@@ -14,6 +14,7 @@
 
 from logging import ERROR, INFO
 
+from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb.create_architecture import CreateArchitecture
 
 
@@ -34,7 +35,9 @@ class TestCreateArchitecture:
         mocker.patch.object(architecture_mock,
                             'export',
                             side_effect=OSError(''))
-        create_arch = CreateArchitecture('', 10, architecture_mock)
+        create_arch = CreateArchitecture('',
+                                         MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                         architecture_mock)
 
         create_arch.create('output_path', True)
         assert len(caplog.records) == 1

--- a/test/verb/test_create_architecture.py
+++ b/test/verb/test_create_architecture.py
@@ -14,8 +14,8 @@
 
 from logging import ERROR, INFO
 
-from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
-from ros2caret.verb.create_architecture import CreateArchitecture
+from ros2caret.verb.create_architecture import (CreateArchitecture,
+                                                max_callback_construction_order_on_path_searching)
 
 
 class TestCreateArchitecture:
@@ -23,7 +23,9 @@ class TestCreateArchitecture:
     def test_create_success_case(self, caplog, mocker):
         architecture_mock = mocker.Mock()
         mocker.patch.object(architecture_mock, 'export', return_value=None)
-        create_arch = CreateArchitecture('', 10, architecture_mock)
+        create_arch = CreateArchitecture('',
+                                         max_callback_construction_order_on_path_searching,
+                                         architecture_mock)
 
         create_arch.create('output_path', True)
         assert len(caplog.records) == 1
@@ -36,7 +38,7 @@ class TestCreateArchitecture:
                             'export',
                             side_effect=OSError(''))
         create_arch = CreateArchitecture('',
-                                         MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                         max_callback_construction_order_on_path_searching,
                                          architecture_mock)
 
         create_arch.create('output_path', True)

--- a/test/verb/test_verify_paths.py
+++ b/test/verb/test_verify_paths.py
@@ -27,7 +27,7 @@ class TestVerifyPaths:
                             'get_path',
                             return_value=path_mock)
 
-        verify_paths = VerifyPaths('', architecture_mock)
+        verify_paths = VerifyPaths('', 10, architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 1
         record = caplog.records[0]
@@ -41,6 +41,6 @@ class TestVerifyPaths:
                             'get_path',
                             return_value=path_mock)
 
-        verify_paths = VerifyPaths('', architecture_mock)
+        verify_paths = VerifyPaths('', 10, architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 0

--- a/test/verb/test_verify_paths.py
+++ b/test/verb/test_verify_paths.py
@@ -16,10 +16,10 @@ from logging import INFO
 
 try:
     import os
-    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+    from caret_analyze import DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
-        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
+        DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
     else:
         raise e
 
@@ -37,7 +37,7 @@ class TestVerifyPaths:
                             return_value=path_mock)
 
         verify_paths = VerifyPaths('',
-                                   MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                   DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                    architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 1
@@ -53,7 +53,7 @@ class TestVerifyPaths:
                             return_value=path_mock)
 
         verify_paths = VerifyPaths('',
-                                   MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                   DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                    architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 0

--- a/test/verb/test_verify_paths.py
+++ b/test/verb/test_verify_paths.py
@@ -14,6 +14,7 @@
 
 from logging import INFO
 
+from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from ros2caret.verb.verify_paths import VerifyPaths
 
 
@@ -41,6 +42,8 @@ class TestVerifyPaths:
                             'get_path',
                             return_value=path_mock)
 
-        verify_paths = VerifyPaths('', 10, architecture_mock)
+        verify_paths = VerifyPaths('',
+                                   MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                   architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 0

--- a/test/verb/test_verify_paths.py
+++ b/test/verb/test_verify_paths.py
@@ -14,8 +14,8 @@
 
 from logging import INFO
 
-from ros2caret.verb.verify_paths import (max_callback_construction_order_on_path_searching,
-                                         VerifyPaths)
+from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from ros2caret.verb.verify_paths import VerifyPaths
 
 
 class TestVerifyPaths:
@@ -29,7 +29,7 @@ class TestVerifyPaths:
                             return_value=path_mock)
 
         verify_paths = VerifyPaths('',
-                                   max_callback_construction_order_on_path_searching,
+                                   MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                    architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 1
@@ -45,7 +45,7 @@ class TestVerifyPaths:
                             return_value=path_mock)
 
         verify_paths = VerifyPaths('',
-                                   max_callback_construction_order_on_path_searching,
+                                   MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
                                    architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 0

--- a/test/verb/test_verify_paths.py
+++ b/test/verb/test_verify_paths.py
@@ -14,7 +14,15 @@
 
 from logging import INFO
 
-from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+try:
+    import os
+    from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+except ModuleNotFoundError as e:
+    if 'GITHUB_ACTION' in os.environ:
+        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
+    else:
+        raise e
+
 from ros2caret.verb.verify_paths import VerifyPaths
 
 

--- a/test/verb/test_verify_paths.py
+++ b/test/verb/test_verify_paths.py
@@ -14,8 +14,8 @@
 
 from logging import INFO
 
-from caret_analyze import MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
-from ros2caret.verb.verify_paths import VerifyPaths
+from ros2caret.verb.verify_paths import (max_callback_construction_order_on_path_searching,
+                                         VerifyPaths)
 
 
 class TestVerifyPaths:
@@ -28,7 +28,9 @@ class TestVerifyPaths:
                             'get_path',
                             return_value=path_mock)
 
-        verify_paths = VerifyPaths('', 10, architecture_mock)
+        verify_paths = VerifyPaths('',
+                                   max_callback_construction_order_on_path_searching,
+                                   architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 1
         record = caplog.records[0]
@@ -43,7 +45,7 @@ class TestVerifyPaths:
                             return_value=path_mock)
 
         verify_paths = VerifyPaths('',
-                                   MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING,
+                                   max_callback_construction_order_on_path_searching,
                                    architecture_mock)
         verify_paths.verify(['verified_path_name'])
         assert len(caplog.records) == 0


### PR DESCRIPTION
## Description

Added max_construction_order argument to commands using Architecture-API.

## Related links

[https://tier4.atlassian.net/browse/RT2-1261](https://tier4.atlassian.net/browse/RT2-1261)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
