### PR TITLE
fix: total number of processes becomes None

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -67,10 +67,8 @@ class CaretSessionNode(Node):
         if msg.caret_node_name in self._caret_node_names:
             self._caret_node_names.remove(msg.caret_node_name)
         else:
-           return
-
-        if self._progress:
-            self._progress.update()
+            if self._progress:
+                self._progress.update()
 
         if len(self._caret_node_names) == 0:
             self.stop_progress()

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -66,7 +66,6 @@ class CaretSessionNode(Node):
 
         if msg.caret_node_name in self._caret_node_names:
             self._caret_node_names.remove(msg.caret_node_name)
-        else:
             if self._progress:
                 self._progress.update()
 

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -66,6 +66,8 @@ class CaretSessionNode(Node):
 
         if msg.caret_node_name in self._caret_node_names:
             self._caret_node_names.remove(msg.caret_node_name)
+        else:
+           return
 
         if self._progress:
             self._progress.update()


### PR DESCRIPTION
## Description

When using the -v option during measurement in a multi-host environment, the total number of processes to be measured becomes None.

## Related links

https://tier4.atlassian.net/browse/RT2-1593

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
