### PR TITLE
fix: add retry for init LTTng

### DIFF
--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -154,6 +154,11 @@ class RecordVerb(VerbExtension):
         parser.add_argument(
             '-c', '--record-clock', dest='record_clock', action='store_true',
             help='launch the node where the /clock topic is stored to use ROS time. ')
+        parser.add_argument(
+            '--init-retry-num', dest='init_retry_num', type=int,
+            default=10,
+            help='retry num to initialize LTTng')
+
 
     def main(self, *, args):
         if args.light_mode:
@@ -221,7 +226,16 @@ class RecordVerb(VerbExtension):
             raise ValueError('--subbuffer-size-kernel value must be power of two.')
         init_args['subbuffer_size_kernel'] = args.subbuffer_size_kernel
         init_args['immediate'] = args.immediate
-        init(**init_args)
+
+        for i in range(args.init_retry_num):
+            init_result = init(**init_args)
+            if init_result:
+                break
+            print(f'Failed to init LTTng. retry {i} / {args.init_retry_num}')
+            time.sleep(1)
+        if not init_result:
+            print('Failed to init LTTng.')
+            exit(0)
 
         def _run():
             recordable_node_num = node.start(args.verbose, args.recording_frequency)
@@ -230,7 +244,7 @@ class RecordVerb(VerbExtension):
             try:
                 input('press enter to stop...')
             except EOFError:
-                print('\nstd::input is not supported in this system. press ctrl-c to stop...')
+                print('\nstd::input is not supported in this system.\npress ctrl-c to stop...')
                 while True:
                     time.sleep(10)
 

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -159,7 +159,6 @@ class RecordVerb(VerbExtension):
             default=10,
             help='retry num to initialize LTTng')
 
-
     def main(self, *, args):
         if args.light_mode:
             events_ust = [

--- a/ros2caret/verb/record.py
+++ b/ros2caret/verb/record.py
@@ -233,7 +233,7 @@ class RecordVerb(VerbExtension):
                 break
             print(f'Failed to init LTTng. retry {i} / {args.init_retry_num}')
             time.sleep(1)
-        if not init_result:
+        else:
             print('Failed to init LTTng.')
             exit(0)
 


### PR DESCRIPTION
## Description

### Issue to be fixed

- [caret_record_init](https://github.com/tier4/ros2caret/blob/v0.5.12/ros2caret/verb/caret_record_init.py#L45) may return error (False), but error is not handled by [the caller](https://github.com/tier4/ros2caret/blob/v0.5.12/ros2caret/verb/record.py#L224)
- The error happens when `lttng-sessiond --daemonize` fails in [here](https://github.com/tier4/ros2_tracing/blob/humble_tracepoint_added/tracetools_trace/tracetools_trace/tools/lttng_impl.py#L106)

### Specific error case

- There are two processes who tries to run `lttng-sessiond --daemonize` when it's not launched
  - [~/ros2_caret_ws/setenv_caret.bash](https://github.com/tier4/caret/blob/v0.5.12/ansible/roles/caret/templates/setenv_caret.bash.jinja2#L12)
  - [ros2 caret record](https://github.com/tier4/ros2_tracing/blob/humble_tracepoint_added/tracetools_trace/tracetools_trace/tools/lttng_impl.py#L106)
- If a user run the both commands at the same time, `lttng-sessiond --daemonize` by `ros2 caret record` fails and tracing doesn't start (although the process continues)
- Log

```
Error: No session daemon is available
UST tracing enabled (16 events)
kernel tracing disabled
context (3 fields)
writing tracing session to: /home/autoware/.ros/tracing/session-20241119014758
Error: Could not get lock file `/home/autoware/.lttng/lttng-sessiond.lck`, another instance is running.
Error: A session daemon is already running.
error: failed to start lttng session daemon
press enter to stop...
std::input is not supported in this system. press ctrl-c to stop...
```

## Related links

None

## Notes for reviewers

I used the script like the following to cause the conflict, but it's still hard to reproduce the error. The error occurs only on a specific instance on the AWS

```sh
(. ~/work/project/caret/install/local_setup.bash && ros2 caret record --light --immediate -f 50000) &
. ~/work/project/caret/setenv_caret.bash
```

I confirmed it was fixed and the retry logic works as expected

```
Error: No session daemon is available
UST tracing enabled (16 events)
kernel tracing disabled
context (3 fields)
writing tracing session to: /home/autoware/.ros/tracing/session-20241119025321
Error: Could not get lock file `/home/autoware/.lttng/lttng-sessiond.lck`, another instance is running.
Error: A session daemon is already running.
error: failed to start lttng session daemon
Failed to init LTTng. retry 0 / 10
UST tracing enabled (16 events)
kernel tracing disabled
context (3 fields)
writing tracing session to: /home/autoware/.ros/tracing/session-20241119025321
press enter to stop...
std::input is not supported in this system.
press ctrl-c to stop...
```

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
