### PR TITLE
fix: change tests_require to extras_require in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+tabulate

--- a/ros2caret/verb/verify_paths.py
+++ b/ros2caret/verb/verify_paths.py
@@ -82,7 +82,7 @@ class VerifyPaths:
         arch_path: str,
         max_callback_construction_order_on_path_searching: int,
         architecture: Optional[Architecture] = None
-    ) -> None:
+    ) -> None:  # type: ignore
         if architecture:
             self._arch = architecture
         else:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer_email='yamasaki@isp.co.jp, uetsuki@isp.co.jp',
     description='TODO: Package description',
     license='Apache License 2.0',
-    extras_require = {
+    extras_require={
         'test': [
             'pytest',
         ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,11 @@ setup(
     maintainer_email='yamasaki@isp.co.jp, uetsuki@isp.co.jp',
     description='TODO: Package description',
     license='Apache License 2.0',
-    tests_require=['pytest'],
+    extras_require = {
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'caret = ros2caret.command.caret:CaretCommand',


### PR DESCRIPTION
…om tests_require to extras_require.

## Description

In setup.py, change the test dependency description from tests_require to extras_require.
[https://github.com/tier4/ros2caret/issues/208](https://github.com/tier4/ros2caret/issues/208)

## Related links

[https://tier4.atlassian.net/browse/RT0-38753](https://tier4.atlassian.net/browse/RT0-38753)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
